### PR TITLE
Dev updates

### DIFF
--- a/example/config/settings.py
+++ b/example/config/settings.py
@@ -63,9 +63,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        "NAME": (
-            "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
-        ),
+        "NAME": ("django.contrib.auth.password_validation.UserAttributeSimilarityValidator"),
     },
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",

--- a/example/config/settings_testing.py
+++ b/example/config/settings_testing.py
@@ -19,6 +19,8 @@ CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"
 # Changing these settings will affect lots of tests!
 BLOG_TITLE = "My Test DJ Press Blog"
 BLOG_DESCRIPTION = "This is a test blog."
+ARCHIVES_PATH = "test-url-archives"
+ARCHIVES_PATH_ENABLED = True
 AUTHOR_PATH_ENABLED = True
 AUTHOR_PATH = "test-url-author"
 CATEGORY_PATH_ENABLED = True
@@ -31,3 +33,4 @@ CACHE_CATEGORIES = True
 RECENT_PUBLISHED_POSTS_COUNT = 3
 DATE_ARCHIVES_ENABLED = True
 POST_READ_MORE_TEXT = "Test read more..."
+RSS_PATH = "test-rss"

--- a/justfile
+++ b/justfile
@@ -5,52 +5,55 @@ default:
 # Set the Python version
 python_version := "3.12"
 
+# Set the uv run command
+uv := "uv run --python 3.12 --extra test"
+
 # Run the Django development server
 run:
     @just sync
-    uv run --python {{python_version}} example/manage.py runserver
+    {{uv}} example/manage.py runserver
 
 # Make migrations
 makemigrations:
-    uv run --python {{python_version}} example/manage.py makemigrations
+    {{uv}} example/manage.py makemigrations
 
 # Apply migrations
 migrate:
-    uv run --python {{python_version}} example/manage.py migrate
+    {{uv}} example/manage.py migrate
 
 # Create a superuser
 createsuperuser:
-    uv run --python {{python_version}} example/manage.py createsuperuser
+    {{uv}} example/manage.py createsuperuser
 
 # Collect static files
 collectstatic:
-    uv run --python {{python_version}} example/manage.py collectstatic
+    {{uv}} example/manage.py collectstatic
 
 # Run Django shell
 shell:
-    uv run --python {{python_version}} example/manage.py shell
+    {{uv}} example/manage.py shell
 
 # Check for any problems in your project
 check:
-    uv run --python {{python_version}} example/manage.py check
+    {{uv}} example/manage.py check
 
 # Run pytest
 test:
-    uv run --python {{python_version}} pytest
+    {{uv}} pytest
 
-# Run tox
-tox:
-    uv run --python {{python_version}} tox
+# Run nox
+nox:
+    uv tool run nox --session test
 
 # Run coverage
 cov:
-    uv run --python {{python_version}} coverage run -m pytest
-    uv run --python {{python_version}} coverage report -m
+    {{uv}} coverage run -m pytest
+    {{uv}} coverage report -m
 
 # Run coverage
 cov-html:
-    uv run --python {{python_version}} coverage run -m pytest
-    uv run --python {{python_version}} coverage html
+    {{uv}} coverage run -m pytest
+    {{uv}} coverage html
 
 # Sync the package
 sync:
@@ -72,7 +75,7 @@ publish:
       uv tool run twine upload dist/*
 
 # Upgrade pre-commit hooks
-pc-upgrade:
+pc-up:
     uv tool run pre-commit autoupdate
 
 # Run pre-commit hooks

--- a/justfile
+++ b/justfile
@@ -8,6 +8,9 @@ python_version := "3.12"
 # Set the uv run command
 uv := "uv run --python 3.12 --extra test"
 
+#Set the uv command to run a tool
+uv-tool := "uv tool run"
+
 # Run the Django development server
 run:
     @just sync
@@ -41,9 +44,17 @@ check:
 test:
     {{uv}} pytest
 
+# Run Ruff linking
+lint:
+    {{uv-tool}} ruff check
+
+# Run Ruff formatting
+format:
+    {{uv-tool}} ruff format
+
 # Run nox
 nox:
-    uv tool run nox --session test
+    {{uv-tool}} nox --session test
 
 # Run coverage
 cov:
@@ -71,13 +82,13 @@ build:
 publish:
       rm -rf ./dist/*
       uv build
-      uv tool run twine check dist/*
-      uv tool run twine upload dist/*
+      {{uv-tool}} twine check dist/*
+      {{uv-tool}} twine upload dist/*
 
 # Upgrade pre-commit hooks
 pc-up:
-    uv tool run pre-commit autoupdate
+    {{uv-tool}} pre-commit autoupdate
 
 # Run pre-commit hooks
 pc-run:
-    uv tool run pre-commit run --all-files
+    {{uv-tool}} pre-commit run --all-files

--- a/justfile
+++ b/justfile
@@ -45,6 +45,11 @@ tox:
 # Run coverage
 cov:
     uv run --python {{python_version}} coverage run -m pytest
+    uv run --python {{python_version}} coverage report -m
+
+# Run coverage
+cov-html:
+    uv run --python {{python_version}} coverage run -m pytest
     uv run --python {{python_version}} coverage html
 
 # Sync the package

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,12 @@
+"""Nox file."""
+
+import nox
+
+
+@nox.session(venv_backend="uv", python=["3.10", "3.11", "3.12"])
+@nox.parametrize("django_ver", ["~=4.2.0", "~=5.0.0", "~=5.1.0"])
+def test(session: nox.Session, django_ver: str) -> None:
+    """Run the test suite."""
+    session.install(".", "--all-extras", "-r", "pyproject.toml")
+    session.install(f"django{django_ver}")
+    session.run("pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,3 +97,11 @@ deps =
 commands =
     pytest
 """
+
+[tool.coverage.run]
+branch = true
+include = ["src/djpress/*"]
+omit = [
+  "*/tests/*",
+  "*/migrations/*",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,11 @@ Repository = "https://github.com/stuartmaxwell/djpress"
 Issues = "https://github.com/stuartmaxwell/djpress/issues"
 
 [project.optional-dependencies]
-test = ["pytest>=8.3.3", "pytest-django>=4.9.0"]
+test = [
+    "pytest>=8.3.3",
+    "pytest-django>=4.9.0",
+    "coverage>=7.6.1",
+]
 
 [tool.ruff.lint]
 select = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ test = [
     "django-debug-toolbar>=4.4.0",
 ]
 
+[tool.ruff]
+line-length = 120
+
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "djpress"
-version = "0.8.0"
+version = "0.8.1"
 description = "A blog application for Django sites, inspired by classic WordPress."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -39,10 +39,10 @@ Issues = "https://github.com/stuartmaxwell/djpress/issues"
 
 [project.optional-dependencies]
 test = [
-    "pytest>=8.3.3",
-    "pytest-django>=4.9.0",
-    "coverage>=7.6.1",
-    "django-debug-toolbar>=4.4.0",
+  "pytest>=8.3.3",
+  "pytest-django>=4.9.0",
+  "coverage>=7.6.1",
+  "django-debug-toolbar>=4.4.0",
 ]
 
 [tool.ruff]
@@ -76,7 +76,4 @@ python_files = "tests.py test_*.py *_tests.py"
 [tool.coverage.run]
 branch = true
 include = ["src/djpress/*"]
-omit = [
-  "*/tests/*",
-  "*/migrations/*",
-]
+omit = ["*/tests/*", "*/migrations/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "pytest>=8.3.3",
     "pytest-django>=4.9.0",
     "coverage>=7.6.1",
+    "django-debug-toolbar>=4.4.0",
 ]
 
 [tool.ruff.lint]
@@ -68,39 +69,6 @@ convention = "google"
 pythonpath = ". example"
 DJANGO_SETTINGS_MODULE = "config.settings_testing"
 python_files = "tests.py test_*.py *_tests.py"
-
-[tool.uv]
-dev-dependencies = [
-  "coverage>=7.6.1",
-  "django-debug-toolbar>=4.4.0",
-  "tox-uv>=1.11.3",
-]
-
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-env_list =
-    py3{10,11,12}-django{42,50,51}
-    py3{13}-django{51}
-isolated_build = True
-
-[base]
-deps =
-    markdown
-    pygments
-    pytest
-    pytest-django
-
-[testenv]
-description = Run the tests with pytest and uv
-deps =
-    {[base]deps}
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
-    django51: Django>=5.1,<5.2
-commands =
-    pytest
-"""
 
 [tool.coverage.run]
 branch = true

--- a/src/djpress/exceptions.py
+++ b/src/djpress/exceptions.py
@@ -3,3 +3,11 @@
 
 class SlugNotFoundError(Exception):
     """Exception raised when the slug is missing from the URL path."""
+
+
+class PostNotFoundError(Exception):
+    """Exception raised when the post is not found in the database."""
+
+
+class PageNotFoundError(Exception):
+    """Exception raised when the page is not found in the database."""

--- a/src/djpress/exceptions.py
+++ b/src/djpress/exceptions.py
@@ -1,0 +1,5 @@
+"""Custom exceptions for the djpress package."""
+
+
+class SlugNotFoundError(Exception):
+    """Exception raised when the slug is missing from the URL path."""

--- a/src/djpress/templatetags/djpress_tags.py
+++ b/src/djpress/templatetags/djpress_tags.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 from djpress.conf import settings
+from djpress.exceptions import PageNotFoundError
 from djpress.models import Category, Post
 from djpress.templatetags.helpers import (
     categories_html,
@@ -687,7 +688,7 @@ def page_link(
     """
     try:
         page: Post | None = Post.page_objects.get_published_page_by_slug(page_slug)
-    except ValueError:
+    except PageNotFoundError:
         return ""
 
     output = get_page_link(page, link_class=link_class)

--- a/src/djpress/templatetags/djpress_tags.py
+++ b/src/djpress/templatetags/djpress_tags.py
@@ -43,10 +43,7 @@ def blog_title_link(link_class: str = "") -> str:
     """
     link_class_html = f' class="{link_class}"' if link_class else ""
 
-    output = (
-        f'<a href="{reverse("djpress:index")}"{link_class_html}>'
-        f'{settings.BLOG_TITLE}</a>'
-    )
+    output = f'<a href="{reverse("djpress:index")}"{link_class_html}>{settings.BLOG_TITLE}</a>'
 
     return mark_safe(output)
 
@@ -58,9 +55,7 @@ def get_pages() -> models.QuerySet[Post]:
     Returns:
         models.QuerySet[Post]: All pages.
     """
-    return (
-        Post.page_objects.get_published_pages().order_by("menu_order").order_by("title")
-    )
+    return Post.page_objects.get_published_pages().order_by("menu_order").order_by("title")
 
 
 @register.simple_tag
@@ -250,10 +245,7 @@ def post_title_link(context: Context, link_class: str = "") -> str:
 
         link_class_html = f' class="{link_class}"' if link_class else ""
 
-        output = (
-            f'<a href="{post_url}" title="{post.title}"{link_class_html}>'
-            f"{post.title}</a>"
-        )
+        output = f'<a href="{post_url}" title="{post.title}"{link_class_html}>{post.title}</a>'
 
         return mark_safe(output)
 
@@ -668,16 +660,10 @@ def pagination_links(
     else:
         next_output = ""
 
-    current_output = (
-        f'<span class="current">'
-        f"Page {page.number} of {page.paginator.num_pages}"
-        f"</span>"
-    )
+    current_output = f'<span class="current">Page {page.number} of {page.paginator.num_pages}</span>'
 
     return mark_safe(
-        f'<div class="pagination">'
-        f"{previous_output} {current_output} {next_output}"
-        "</div>",
+        f'<div class="pagination">{previous_output} {current_output} {next_output}</div>',
     )
 
 

--- a/src/djpress/templatetags/helpers.py
+++ b/src/djpress/templatetags/helpers.py
@@ -87,10 +87,7 @@ def get_page_link(page: Post, link_class: str = "") -> str:
 
     link_class_html = f' class="{link_class}"' if link_class else ""
 
-    return (
-        f'<a href="{page_url}" title="View the {page.title} page"'
-        f"{link_class_html}>{page.title}</a>"
-    )
+    return f'<a href="{page_url}" title="View the {page.title} page"{link_class_html}>{page.title}</a>'
 
 
 def post_read_more_link(

--- a/src/djpress/urls.py
+++ b/src/djpress/urls.py
@@ -12,21 +12,36 @@ from djpress.views import (
     post_detail,
 )
 
-regex_path = r"^(?P<path>[0-9A-Za-z/_-]*)$"
 
-# The following regex is used to match the archives path. It is used to match
-# the following patterns:
-# - 2024
-# - 2024/01
-# - 2024/01/01
-# There will always be a year.
-# If there is a month, there will always be a year.
-# If there is a day, there will always be a month and a year.
-regex_archives = r"(?P<year>\d{4})(?:/(?P<month>\d{2})(?:/(?P<day>\d{2}))?)?$"
+def regex_path() -> str:
+    """Generate the regex path for the post detail view.
 
-if settings.APPEND_SLASH:
-    regex_path = regex_path[:-1] + "/$"
-    regex_archives = regex_archives[:-1] + "/$"
+    The following regex is used to match the path. It is used to match the
+    any path that contains letters, numbers, underscores, hyphens, and slashes.
+    """
+    regex = r"^(?P<path>[0-9A-Za-z/_-]*)$"
+    if settings.APPEND_SLASH:
+        return regex[:-1] + "/$"
+    return regex
+
+
+def regex_archives() -> str:
+    """Generate the regex path for the archives view.
+
+    The following regex is used to match the archives path. It is used to match
+    the following patterns:
+    - 2024
+    - 2024/01
+    - 2024/01/01
+    There will always be a year.
+    If there is a month, there will always be a year.
+    If there is a day, there will always be a month and a year.
+    """
+    regex = r"(?P<year>\d{4})(?:/(?P<month>\d{2})(?:/(?P<day>\d{2}))?)?$"
+    if settings.APPEND_SLASH:
+        return regex[:-1] + "/$"
+    return regex
+
 
 app_name = "djpress"
 
@@ -53,7 +68,7 @@ if settings.AUTHOR_PATH_ENABLED:
 if settings.ARCHIVES_PATH_ENABLED and settings.ARCHIVES_PATH:
     urlpatterns += [
         re_path(
-            settings.ARCHIVES_PATH + "/" + regex_archives,
+            settings.ARCHIVES_PATH + "/" + regex_archives(),
             archives_posts,
             name="archives_posts",
         ),
@@ -71,7 +86,7 @@ if settings.RSS_ENABLED and settings.RSS_PATH:
 urlpatterns += [
     path("", index, name="index"),
     re_path(
-        regex_path,
+        regex_path(),
         post_detail,
         name="post_detail",
     ),

--- a/src/djpress/utils.py
+++ b/src/djpress/utils.py
@@ -1,11 +1,15 @@
 """Utility functions that are used in the project."""
 
+import re
+from typing import NamedTuple
+
 import markdown
 from django.contrib.auth.models import User
 from django.template.loader import TemplateDoesNotExist, select_template
 from django.utils import timezone
 
 from djpress.conf import settings
+from djpress.exceptions import SlugNotFoundError
 
 md = markdown.Markdown(
     extensions=settings.MARKDOWN_EXTENSIONS,
@@ -74,13 +78,13 @@ def validate_date(year: str, month: str, day: str) -> None:
 
     try:
         if int_month and int_day:
-            timezone.datetime(int_year, int_month, int_day)
+            timezone.make_aware(timezone.datetime(int_year, int_month, int_day))
 
         elif int_month:
-            timezone.datetime(int_year, int_month, 1)
+            timezone.make_aware(timezone.datetime(int_year, int_month, 1))
 
         else:
-            timezone.datetime(int_year, 1, 1)
+            timezone.make_aware(timezone.datetime(int_year, 1, 1))
 
     except ValueError as exc:
         msg = "Invalid date"
@@ -103,3 +107,84 @@ def get_template_name(templates: list[str]) -> str:
         raise TemplateDoesNotExist(msg) from exc
 
     return template
+
+
+class PathParts(NamedTuple):
+    """Named tuple for the path parts.
+
+    These are extracted by the extract_parts_from_path function.
+
+    Attributes:
+        year (int | None): The year.
+        month (int | None): The month.
+        day (int | None): The day.
+        slug (str): The slug.
+    """
+
+    year: int | None
+    month: int | None
+    day: int | None
+    slug: str
+
+
+def extract_parts_from_path(path: str) -> PathParts:
+    """Extract the parts from the path.
+
+    Args:
+        path (str): The path.
+
+    Returns:
+        PathParts: The parts extracted from the path.
+    """
+    # Remove leading and trailing slashes
+    path = path.strip("/")
+
+    # Build the regex pattern
+    pattern_parts = []
+
+    post_prefix = settings.POST_PREFIX
+    post_permalink = settings.POST_PERMALINK
+
+    # Add the post prefix to the pattern, if it exists
+    if post_prefix:
+        pattern_parts.append(re.escape(post_prefix))
+
+    # Add the date parts based on the permalink structure
+    if post_permalink:
+        if "%Y" in post_permalink:
+            post_permalink = post_permalink.replace("%Y", r"(?P<year>\d{4})")
+        if "%m" in post_permalink:
+            post_permalink = post_permalink.replace("%m", r"(?P<month>\d{2})")
+        if "%d" in post_permalink:
+            post_permalink = post_permalink.replace("%d", r"(?P<day>\d{2})")
+        pattern_parts.append(post_permalink)
+
+    # Add the slug capture group
+    pattern_parts.append(r"(?P<slug>[0-9A-Za-z_/-]+)")  # TODO: repeated code - urls.py
+
+    # Join patterns with optional slashes
+    pattern = "^" + "/".join(f"(?:{part})" for part in pattern_parts) + "$"
+
+    # Attempt to match the pattern
+    match = re.match(pattern, path)
+
+    if not match:
+        msg = "Slug could not be found in the provided path."
+        raise SlugNotFoundError(msg)
+
+    # Extract the date parts and slug
+    year = match.group("year") if "year" in match.groupdict() else None
+    month = match.group("month") if "month" in match.groupdict() else None
+    day = match.group("day") if "day" in match.groupdict() else None
+    slug = match.group("slug") if "slug" in match.groupdict() else None
+
+    if not slug:
+        msg = "Slug could not be found in the provided path."
+        raise SlugNotFoundError(msg)
+
+    # Convert year, month, day to integers (or None if not present)
+    year = int(year) if year else None
+    month = int(month) if month else None
+    day = int(day) if day else None
+
+    return PathParts(year=year, month=month, day=day, slug=slug)

--- a/src/djpress/views.py
+++ b/src/djpress/views.py
@@ -12,6 +12,7 @@ from django.http import Http404, HttpRequest, HttpResponse, HttpResponseBadReque
 from django.shortcuts import render
 
 from djpress.conf import settings
+from djpress.exceptions import SlugNotFoundError
 from djpress.models import Category, Post
 from djpress.utils import get_template_name, validate_date
 
@@ -223,9 +224,14 @@ def post_detail(request: HttpRequest, path: str) -> HttpResponse:
         # If the page is found, use the page template
         template_names.insert(0, "djpress/page.html")
     except ValueError:
+        # A ValueError means we were able to parse the path, but the page was not found
         try:
             post = Post.post_objects.get_published_post_by_path(path)
             context: dict = {"post": post}
+        except SlugNotFoundError as exc:
+            # A SlugNotFoundError means we were not able to parse the path
+            msg = "Post not found"
+            raise Http404(msg) from exc
         except ValueError as exc:
             msg = "Post not found"
             raise Http404(msg) from exc

--- a/src/djpress/views.py
+++ b/src/djpress/views.py
@@ -230,12 +230,8 @@ def post_detail(request: HttpRequest, path: str) -> HttpResponse:
         try:
             post = Post.post_objects.get_published_post_by_path(path)
             context: dict = {"post": post}
-        except SlugNotFoundError as exc:
+        except (PostNotFoundError, SlugNotFoundError) as exc:
             # A SlugNotFoundError means we were not able to parse the path
-            msg = "Post not found"
-            raise Http404(msg) from exc
-        except PostNotFoundError as exc:
-            # A PostNotFoundError means we were able to parse the path, but the post was not found
             msg = "Post not found"
             raise Http404(msg) from exc
 

--- a/tests/test_feeds.py
+++ b/tests/test_feeds.py
@@ -13,12 +13,8 @@ def user():
 
 @pytest.mark.django_db
 def test_latest_posts_feed(client, user):
-    Post.post_objects.create(
-        title="Post 1", content="Content of post 1.", author=user, status="published"
-    )
-    Post.post_objects.create(
-        title="Post 2", content="Content of post 2.", author=user, status="published"
-    )
+    Post.post_objects.create(title="Post 1", content="Content of post 1.", author=user, status="published")
+    Post.post_objects.create(title="Post 2", content="Content of post 2.", author=user, status="published")
 
     url = reverse("djpress:rss_feed")
     response = client.get(url)
@@ -65,6 +61,4 @@ def test_truncated_posts_feed(client, user):
     assert "<item>" in feed
     assert "<title>Post 1</title>" in feed
     assert "Truncated content" not in feed
-    assert (
-        f'&lt;a href="/{post_prefix}/post-1/"&gt;Read more&lt;/a&gt;&lt;/p&gt;' in feed
-    )
+    assert f'&lt;a href="/{post_prefix}/post-1/"&gt;Read more&lt;/a&gt;&lt;/p&gt;' in feed

--- a/tests/test_models_category.py
+++ b/tests/test_models_category.py
@@ -34,10 +34,7 @@ def test_category_save_slug_uniqueness():
     with pytest.raises(ValueError) as excinfo:
         category2.save()
 
-    assert (
-        str(excinfo.value)
-        == f"A category with the slug {category2.slug} already exists."
-    )
+    assert str(excinfo.value) == f"A category with the slug {category2.slug} already exists."
 
 
 @pytest.mark.django_db

--- a/tests/test_models_post.py
+++ b/tests/test_models_post.py
@@ -565,3 +565,6 @@ def test_get_cached_recent_published_posts(user, mock_timezone_now, monkeypatch)
         kwargs.get("timeout") or args[2]
     )  # timeout might be a kwarg or the third positional arg
     assert abs(actual_timeout - expected_timeout) < 5  # Allow a small margin of error
+
+    settings.set("CACHE_RECENT_PUBLISHED_POSTS", False)
+    assert settings.CACHE_RECENT_PUBLISHED_POSTS is False

--- a/tests/test_models_post.py
+++ b/tests/test_models_post.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 from unittest.mock import patch
 
 from djpress.models.post import PUBLISHED_POSTS_CACHE_KEY
-from djpress.exceptions import SlugNotFoundError
+from djpress.exceptions import SlugNotFoundError, PostNotFoundError, PageNotFoundError
 
 
 @pytest.fixture
@@ -160,7 +160,7 @@ def test_get_published_post_by_slug_with_future_date(user):
         post_type="post",
         date=timezone.now() + timezone.timedelta(days=1),
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(PostNotFoundError):
         Post.post_objects.get_published_post_by_slug("future-post")
 
 
@@ -473,8 +473,8 @@ def test_get_published_post_by_path(user):
     # Test case 3: POST_PREFIX is not set but path starts with POST_PREFIX
     settings.set("POST_PREFIX", "")
     post_path = f"test-posts/non-existent-slug"
-    # Should raise a ValueError since we can parse the path but the slug doesn't exist
-    with pytest.raises(ValueError):
+    # Should raise a PostNotFoundError since we can parse the path but the post doesn't exist
+    with pytest.raises(PostNotFoundError):
         Post.post_objects.get_published_post_by_path(post_path)
 
     # # Test case 4: POST_PREFIX is set and POST_PERMALINK is set
@@ -493,7 +493,7 @@ def test_get_published_page_by_slug(test_page1):
     """Test that the get_published_page_by_slug method returns the correct page."""
     assert test_page1 == Post.page_objects.get_published_page_by_slug("test-page1")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(PageNotFoundError):
         Post.page_objects.get_published_page_by_slug("non-existent-page")
 
 
@@ -518,7 +518,7 @@ def test_get_published_page_by_path(test_page1: Post):
 
     # Test case 3: pages doesn't exist
     page_path = "non-existent-page"
-    with pytest.raises(expected_exception=ValueError):
+    with pytest.raises(expected_exception=PageNotFoundError):
         Post.page_objects.get_published_page_by_path(page_path)
 
 

--- a/tests/test_templatetags_djpress_tags.py
+++ b/tests/test_templatetags_djpress_tags.py
@@ -13,6 +13,7 @@ from djpress.templatetags.helpers import (
     get_page_link,
 )
 from djpress.utils import get_author_display_name
+from djpress.exceptions import PageNotFoundError
 
 
 @pytest.fixture

--- a/tests/test_templatetags_djpress_tags.py
+++ b/tests/test_templatetags_djpress_tags.py
@@ -481,9 +481,9 @@ def test_post_date_link_with_date_archives_enabled(test_post1):
     post_time = post_date.strftime("%-I:%M %p")
 
     expected_output = (
-        f'<a href="/archives/{post_year}/{post_month}/" title="View all posts in {post_month_name} {post_year}">{post_month_name}</a> '
-        f'<a href="/archives/{post_year}/{post_month}/{post_day}/" title="View all posts on {post_day_name} {post_month_name} {post_year}">{post_day_name}</a>, '
-        f'<a href="/archives/{post_year}/" title="View all posts in {post_year}">{post_year}</a>, '
+        f'<a href="/test-url-archives/{post_year}/{post_month}/" title="View all posts in {post_month_name} {post_year}">{post_month_name}</a> '
+        f'<a href="/test-url-archives/{post_year}/{post_month}/{post_day}/" title="View all posts on {post_day_name} {post_month_name} {post_year}">{post_day_name}</a>, '
+        f'<a href="/test-url-archives/{post_year}/" title="View all posts in {post_year}">{post_year}</a>, '
         f"{post_time}."
     )
 
@@ -508,9 +508,9 @@ def test_post_date_link_with_date_archives_enabled_with_one_link_class(
     post_time = post_date.strftime("%-I:%M %p")
 
     expected_output = (
-        f'<a href="/archives/{post_year}/{post_month}/" title="View all posts in {post_month_name} {post_year}" class="class1">{post_month_name}</a> '
-        f'<a href="/archives/{post_year}/{post_month}/{post_day}/" title="View all posts on {post_day_name} {post_month_name} {post_year}" class="class1">{post_day_name}</a>, '
-        f'<a href="/archives/{post_year}/" title="View all posts in {post_year}" class="class1">{post_year}</a>, '
+        f'<a href="/test-url-archives/{post_year}/{post_month}/" title="View all posts in {post_month_name} {post_year}" class="class1">{post_month_name}</a> '
+        f'<a href="/test-url-archives/{post_year}/{post_month}/{post_day}/" title="View all posts on {post_day_name} {post_month_name} {post_year}" class="class1">{post_day_name}</a>, '
+        f'<a href="/test-url-archives/{post_year}/" title="View all posts in {post_year}" class="class1">{post_year}</a>, '
         f"{post_time}."
     )
 
@@ -535,9 +535,9 @@ def test_post_date_link_with_date_archives_enabled_with_two_link_classes(
     post_time = post_date.strftime("%-I:%M %p")
 
     expected_output = (
-        f'<a href="/archives/{post_year}/{post_month}/" title="View all posts in {post_month_name} {post_year}" class="class1 class2">{post_month_name}</a> '
-        f'<a href="/archives/{post_year}/{post_month}/{post_day}/" title="View all posts on {post_day_name} {post_month_name} {post_year}" class="class1 class2">{post_day_name}</a>, '
-        f'<a href="/archives/{post_year}/" title="View all posts in {post_year}" class="class1 class2">{post_year}</a>, '
+        f'<a href="/test-url-archives/{post_year}/{post_month}/" title="View all posts in {post_month_name} {post_year}" class="class1 class2">{post_month_name}</a> '
+        f'<a href="/test-url-archives/{post_year}/{post_month}/{post_day}/" title="View all posts on {post_day_name} {post_month_name} {post_year}" class="class1 class2">{post_day_name}</a>, '
+        f'<a href="/test-url-archives/{post_year}/" title="View all posts in {post_year}" class="class1 class2">{post_year}</a>, '
         f"{post_time}."
     )
 

--- a/tests/test_templatetags_djpress_tags.py
+++ b/tests/test_templatetags_djpress_tags.py
@@ -395,9 +395,7 @@ def test_post_category_link_with_category_path_with_two_link_classes(category1):
 
     expected_output = f'<a href="/{settings.CATEGORY_PATH}/general/" title="View all posts in the General category" class="class1 class2">{category1.title}</a>'
 
-    assert (
-        djpress_tags.post_category_link(category1, "class1 class2") == expected_output
-    )
+    assert djpress_tags.post_category_link(category1, "class1 class2") == expected_output
 
 
 def test_post_date_no_post():
@@ -568,10 +566,7 @@ def test_post_content_with_posts(test_long_post1):
     # Context should have both a posts and a post to simulate the for post in posts loop
     context = Context({"posts": [test_long_post1], "post": test_long_post1})
 
-    expected_output = (
-        f"{test_long_post1.truncated_content_markdown}"
-        f"{post_read_more_link(test_long_post1)}"
-    )
+    expected_output = f"{test_long_post1.truncated_content_markdown}" f"{post_read_more_link(test_long_post1)}"
 
     assert djpress_tags.post_content(context) == expected_output
 
@@ -617,9 +612,7 @@ def test_category_title(category1):
     assert djpress_tags.category_title(context) == expected_output
 
     # Test case 2 - with options
-    expected_output = (
-        f'<h1 class="title">View posts in the {category1.title} category</h1>'
-    )
+    expected_output = f'<h1 class="title">View posts in the {category1.title} category</h1>'
     assert (
         djpress_tags.category_title(
             context,
@@ -696,10 +689,7 @@ def test_post_categories_ul_class1(test_post1):
 
     expected_output = f'<ul><li><a href="/{settings.CATEGORY_PATH}/general/" title="View all posts in the General category" class="class1">General</a></li></ul>'
 
-    assert (
-        djpress_tags.post_categories_link(context, outer="ul", link_class="class1")
-        == expected_output
-    )
+    assert djpress_tags.post_categories_link(context, outer="ul", link_class="class1") == expected_output
 
 
 @pytest.mark.django_db
@@ -711,12 +701,7 @@ def test_post_categories_ul_class1_class2(test_post1):
 
     expected_output = f'<ul><li><a href="/{settings.CATEGORY_PATH}/general/" title="View all posts in the General category" class="class1 class2">General</a></li></ul>'
 
-    assert (
-        djpress_tags.post_categories_link(
-            context, outer="ul", link_class="class1 class2"
-        )
-        == expected_output
-    )
+    assert djpress_tags.post_categories_link(context, outer="ul", link_class="class1 class2") == expected_output
 
 
 @pytest.mark.django_db
@@ -740,10 +725,7 @@ def test_post_categories_div_class1(test_post1):
 
     expected_output = f'<div><a href="/{settings.CATEGORY_PATH}/general/" title="View all posts in the General category" class="class1">General</a></div>'
 
-    assert (
-        djpress_tags.post_categories_link(context, outer="div", link_class="class1")
-        == expected_output
-    )
+    assert djpress_tags.post_categories_link(context, outer="div", link_class="class1") == expected_output
 
 
 @pytest.mark.django_db
@@ -755,12 +737,7 @@ def test_post_categories_div_class1_class2(test_post1):
 
     expected_output = f'<div><a href="/{settings.CATEGORY_PATH}/general/" title="View all posts in the General category" class="class1 class2">General</a></div>'
 
-    assert (
-        djpress_tags.post_categories_link(
-            context, outer="div", link_class="class1 class2"
-        )
-        == expected_output
-    )
+    assert djpress_tags.post_categories_link(context, outer="div", link_class="class1 class2") == expected_output
 
 
 @pytest.mark.django_db
@@ -784,10 +761,7 @@ def test_post_categories_span_class1(test_post1):
 
     expected_output = f'<span><a href="/{settings.CATEGORY_PATH}/general/" title="View all posts in the General category" class="class1">General</a></span>'
 
-    assert (
-        djpress_tags.post_categories_link(context, outer="span", link_class="class1")
-        == expected_output
-    )
+    assert djpress_tags.post_categories_link(context, outer="span", link_class="class1") == expected_output
 
 
 @pytest.mark.django_db
@@ -799,12 +773,7 @@ def test_post_categories_span_class1_class2(test_post1):
 
     expected_output = f'<span><a href="/{settings.CATEGORY_PATH}/general/" title="View all posts in the General category" class="class1 class2">General</a></span>'
 
-    assert (
-        djpress_tags.post_categories_link(
-            context, outer="span", link_class="class1 class2"
-        )
-        == expected_output
-    )
+    assert djpress_tags.post_categories_link(context, outer="span", link_class="class1 class2") == expected_output
 
 
 @pytest.mark.django_db
@@ -837,13 +806,10 @@ def test_blog_pages(test_page1, test_page2):
     assert test_page2 in pages
 
     expected_output_ul = (
-        f"<ul><li>{get_page_link(page=test_page1)}</li>"
-        f"<li>{get_page_link(page=test_page2)}</li></ul>"
+        f"<ul><li>{get_page_link(page=test_page1)}</li>" f"<li>{get_page_link(page=test_page2)}</li></ul>"
     )
 
-    expected_output_div = (
-        f"<div>{get_page_link(page=test_page1)}, {get_page_link(page=test_page2)}</div>"
-    )
+    expected_output_div = f"<div>{get_page_link(page=test_page1)}, {get_page_link(page=test_page2)}</div>"
 
     expected_output_span = f"<span>{get_page_link(page=test_page1)}, {get_page_link(page=test_page2)}</span>"
 
@@ -860,9 +826,7 @@ def test_blog_page_title(test_post1, test_page1):
 
     # Test case 2 - author page
     context = Context({"author": test_post1.author})
-    assert get_author_display_name(test_post1.author) == djpress_tags.blog_page_title(
-        context
-    )
+    assert get_author_display_name(test_post1.author) == djpress_tags.blog_page_title(context)
 
     # Test case 3 - single post
     context = Context({"post": test_post1})
@@ -1023,11 +987,7 @@ def test_pagination_links_one_page(test_post1, test_post2, test_long_post1):
     context = Context({"posts": page})
 
     previous_output = ""
-    current_output = (
-        f'<span class="current">'
-        f"Page {page.number} of {page.paginator.num_pages}"
-        f"</span>"
-    )
+    current_output = f'<span class="current">' f"Page {page.number} of {page.paginator.num_pages}" f"</span>"
     next_output = ""
 
     expected_output = f'<div class="pagination">{previous_output} {current_output} {next_output}</div>'
@@ -1055,11 +1015,7 @@ def test_pagination_links_two_pages(test_post1, test_post2, test_long_post1):
     context = Context({"posts": page})
 
     previous_output = ""
-    current_output = (
-        f'<span class="current">'
-        f"Page {page.number} of {page.paginator.num_pages}"
-        f"</span>"
-    )
+    current_output = f'<span class="current">' f"Page {page.number} of {page.paginator.num_pages}" f"</span>"
     next_output = (
         f'<span class="next">'
         f'<a href="?page={page.next_page_number()}">next</a> '
@@ -1077,11 +1033,7 @@ def test_pagination_links_two_pages(test_post1, test_post2, test_long_post1):
     context = Context({"posts": page})
 
     previous_output = ""
-    current_output = (
-        f'<span class="current">'
-        f"Page {page.number} of {page.paginator.num_pages}"
-        f"</span>"
-    )
+    current_output = f'<span class="current">' f"Page {page.number} of {page.paginator.num_pages}" f"</span>"
     next_output = (
         f'<span class="next">'
         f'<a href="?page={page.next_page_number()}">next</a> '
@@ -1104,11 +1056,7 @@ def test_pagination_links_two_pages(test_post1, test_post2, test_long_post1):
         f'<a href="?page={page.previous_page_number()}">previous</a>'
         f"</span>"
     )
-    current_output = (
-        f'<span class="current">'
-        f"Page {page.number} of {page.paginator.num_pages}"
-        f"</span>"
-    )
+    current_output = f'<span class="current">' f"Page {page.number} of {page.paginator.num_pages}" f"</span>"
     next_output = ""
 
     expected_output = f'<div class="pagination">{previous_output} {current_output} {next_output}</div>'
@@ -1140,11 +1088,7 @@ def test_pagination_links_three_pages(test_post1, test_post2, test_long_post1):
     context = Context({"posts": page})
 
     previous_output = ""
-    current_output = (
-        f'<span class="current">'
-        f"Page {page.number} of {page.paginator.num_pages}"
-        f"</span>"
-    )
+    current_output = f'<span class="current">' f"Page {page.number} of {page.paginator.num_pages}" f"</span>"
     next_output = (
         f'<span class="next">'
         f'<a href="?page={page.next_page_number()}">next</a> '
@@ -1162,11 +1106,7 @@ def test_pagination_links_three_pages(test_post1, test_post2, test_long_post1):
     context = Context({"posts": page})
 
     previous_output = ""
-    current_output = (
-        f'<span class="current">'
-        f"Page {page.number} of {page.paginator.num_pages}"
-        f"</span>"
-    )
+    current_output = f'<span class="current">' f"Page {page.number} of {page.paginator.num_pages}" f"</span>"
     next_output = (
         f'<span class="next">'
         f'<a href="?page={page.next_page_number()}">next</a> '
@@ -1189,11 +1129,7 @@ def test_pagination_links_three_pages(test_post1, test_post2, test_long_post1):
         f'<a href="?page={page.previous_page_number()}">previous</a>'
         f"</span>"
     )
-    current_output = (
-        f'<span class="current">'
-        f"Page {page.number} of {page.paginator.num_pages}"
-        f"</span>"
-    )
+    current_output = f'<span class="current">' f"Page {page.number} of {page.paginator.num_pages}" f"</span>"
     next_output = (
         f'<span class="next">'
         f'<a href="?page={page.next_page_number()}">next</a> '
@@ -1216,11 +1152,7 @@ def test_pagination_links_three_pages(test_post1, test_post2, test_long_post1):
         f'<a href="?page={page.previous_page_number()}">previous</a>'
         f"</span>"
     )
-    current_output = (
-        f'<span class="current">'
-        f"Page {page.number} of {page.paginator.num_pages}"
-        f"</span>"
-    )
+    current_output = f'<span class="current">' f"Page {page.number} of {page.paginator.num_pages}" f"</span>"
     next_output = ""
 
     expected_output = f'<div class="pagination">{previous_output} {current_output} {next_output}</div>'

--- a/tests/test_templatetags_helpers.py
+++ b/tests/test_templatetags_helpers.py
@@ -81,12 +81,7 @@ def test_categories_html(category1, category2, category3):
         f'<li><a href="/{settings.CATEGORY_PATH}/{category3.slug}/" title="View all posts in the {category3.title} category" class="{link_class}">{category3.title}</a></li>'
         "</ul>"
     )
-    assert (
-        categories_html(
-            categories, outer=outer, outer_class=outer_class, link_class=link_class
-        )
-        == expected_output
-    )
+    assert categories_html(categories, outer=outer, outer_class=outer_class, link_class=link_class) == expected_output
 
     # Test case 2
     outer = "ul"
@@ -99,12 +94,7 @@ def test_categories_html(category1, category2, category3):
         f'<li><a href="/{settings.CATEGORY_PATH}/{category3.slug}/" title="View all posts in the {category3.title} category">{category3.title}</a></li>'
         "</ul>"
     )
-    assert (
-        categories_html(
-            categories, outer=outer, outer_class=outer_class, link_class=link_class
-        )
-        == expected_output
-    )
+    assert categories_html(categories, outer=outer, outer_class=outer_class, link_class=link_class) == expected_output
 
     # Test case 3
     outer = "div"
@@ -117,12 +107,7 @@ def test_categories_html(category1, category2, category3):
         f'<a href="/{settings.CATEGORY_PATH}/{category3.slug}/" title="View all posts in the {category3.title} category" class="{link_class}">{category3.title}</a>'
         "</div>"
     )
-    assert (
-        categories_html(
-            categories, outer=outer, outer_class=outer_class, link_class=link_class
-        )
-        == expected_output
-    )
+    assert categories_html(categories, outer=outer, outer_class=outer_class, link_class=link_class) == expected_output
 
     # Test case 4
     outer = "div"
@@ -135,12 +120,7 @@ def test_categories_html(category1, category2, category3):
         f'<a href="/{settings.CATEGORY_PATH}/{category3.slug}/" title="View all posts in the {category3.title} category">{category3.title}</a>'
         "</div>"
     )
-    assert (
-        categories_html(
-            categories, outer=outer, outer_class=outer_class, link_class=link_class
-        )
-        == expected_output
-    )
+    assert categories_html(categories, outer=outer, outer_class=outer_class, link_class=link_class) == expected_output
 
     # Test case 5
     outer = "span"
@@ -153,12 +133,7 @@ def test_categories_html(category1, category2, category3):
         f'<a href="/{settings.CATEGORY_PATH}/{category3.slug}/" title="View all posts in the {category3.title} category" class="{link_class}">{category3.title}</a>'
         "</span>"
     )
-    assert (
-        categories_html(
-            categories, outer=outer, outer_class=outer_class, link_class=link_class
-        )
-        == expected_output
-    )
+    assert categories_html(categories, outer=outer, outer_class=outer_class, link_class=link_class) == expected_output
 
     # Test case 6
     outer = "span"
@@ -171,12 +146,7 @@ def test_categories_html(category1, category2, category3):
         f'<a href="/{settings.CATEGORY_PATH}/{category3.slug}/" title="View all posts in the {category3.title} category">{category3.title}</a>'
         "</span>"
     )
-    assert (
-        categories_html(
-            categories, outer=outer, outer_class=outer_class, link_class=link_class
-        )
-        == expected_output
-    )
+    assert categories_html(categories, outer=outer, outer_class=outer_class, link_class=link_class) == expected_output
 
 
 @pytest.mark.django_db
@@ -208,5 +178,7 @@ def test_post_read_more_link(test_post):
     # Test case 2 - use all options
     link_class = "read-more"
     read_more_text = "Continue reading"
-    expected_output = f'<p><a href="/{settings.POST_PREFIX}/{test_post.slug}/" class="{link_class}">{read_more_text}</a></p>'
+    expected_output = (
+        f'<p><a href="/{settings.POST_PREFIX}/{test_post.slug}/" class="{link_class}">{read_more_text}</a></p>'
+    )
     assert post_read_more_link(test_post, link_class, read_more_text) == expected_output

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,192 @@
+import pytest
+import importlib
+
+from django.urls import reverse, resolve, NoReverseMatch, clear_url_caches
+
+from djpress import urls as djpress_urls
+from djpress.conf import settings
+from djpress.urls import regex_path, regex_archives
+
+
+def test_regex_path():
+    """Test that the URL is correctly set when APPEND_SLASH is True."""
+    # Default value is True
+    assert settings.APPEND_SLASH is True
+
+    # Test that the URL is correctly set
+    assert regex_path() == r"^(?P<path>[0-9A-Za-z/_-]*)/$"
+
+    settings.set("APPEND_SLASH", False)
+    assert settings.APPEND_SLASH is False
+
+    # Test that the URL is correctly set
+    assert regex_path() == r"^(?P<path>[0-9A-Za-z/_-]*)$"
+
+    # Set back to default value
+    settings.set("APPEND_SLASH", True)
+    assert settings.APPEND_SLASH is True
+
+
+def test_regex_archives():
+    """Test that the URL is correctly set when APPEND_SLASH is True."""
+    # Default value is True
+    assert settings.APPEND_SLASH is True
+
+    # Test that the URL is correctly set
+    assert (
+        regex_archives()
+        == r"(?P<year>\d{4})(?:/(?P<month>\d{2})(?:/(?P<day>\d{2}))?)?/$"
+    )
+
+    settings.set("APPEND_SLASH", False)
+    assert settings.APPEND_SLASH is False
+
+    # Test that the URL is correctly set
+    assert (
+        regex_archives()
+        == r"(?P<year>\d{4})(?:/(?P<month>\d{2})(?:/(?P<day>\d{2}))?)?$"
+    )
+
+    # Set back to default value
+    settings.set("APPEND_SLASH", True)
+    assert settings.APPEND_SLASH is True
+
+
+def test_category_posts_url():
+    """Test that the URL is correctly set when CATEGORY_PATH_ENABLED is True."""
+    # Check default settings
+    assert settings.CATEGORY_PATH_ENABLED is True
+    assert settings.CATEGORY_PATH == "test-url-category"
+
+    url = reverse("djpress:category_posts", kwargs={"slug": "test-slug"})
+    assert url == "/test-url-category/test-slug/"
+
+
+@pytest.mark.urls("djpress.urls")
+def test_category_posts_url_no_CATEGORY_PATH_ENABLED():
+    """Test that the URL is correctly set when CATEGORY_PATH_ENABLED is True."""
+    # Check default settings
+    assert settings.CATEGORY_PATH_ENABLED is True
+    assert settings.CATEGORY_PATH == "test-url-category"
+
+    settings.set("CATEGORY_PATH_ENABLED", False)
+    assert settings.CATEGORY_PATH_ENABLED is False
+
+    # Clear the URL caches
+    clear_url_caches()
+
+    # Reload the URL module to reflect the changed settings
+    importlib.reload(djpress_urls)
+
+    # Try to reverse the URL and check if it's not registered
+    with pytest.raises(NoReverseMatch):
+        reverse("djpress:category_posts", kwargs={"slug": "test-slug"})
+
+    # Set back to default value
+    settings.set("CATEGORY_PATH_ENABLED", True)
+    assert settings.CATEGORY_PATH_ENABLED is True
+
+
+def test_author_posts_url():
+    """Test that the URL is correctly set when AUTHOR_PATH_ENABLED is True."""
+    # Check default settings
+    assert settings.AUTHOR_PATH_ENABLED is True
+    assert settings.AUTHOR_PATH == "test-url-author"
+
+    url = reverse("djpress:author_posts", kwargs={"author": "test-author"})
+    assert url == "/test-url-author/test-author/"
+
+
+@pytest.mark.urls("djpress.urls")
+def test_author_posts_url_no_AUTHOR_PATH_ENABLED():
+    """Test that the URL is correctly set when AUTHOR_PATH_ENABLED is True."""
+    # Check default settings
+    assert settings.AUTHOR_PATH_ENABLED is True
+    assert settings.AUTHOR_PATH == "test-url-author"
+
+    settings.set("AUTHOR_PATH_ENABLED", False)
+    assert settings.AUTHOR_PATH_ENABLED is False
+
+    # Clear the URL caches
+    clear_url_caches()
+
+    # Reload the URL module to reflect the changed settings
+    importlib.reload(djpress_urls)
+
+    # Try to reverse the URL and check if it's not registered
+    with pytest.raises(NoReverseMatch):
+        reverse("djpress:author_posts", kwargs={"author": "test-author"})
+
+    # Set back to default value
+    settings.set("AUTHOR_PATH_ENABLED", True)
+    assert settings.AUTHOR_PATH_ENABLED is True
+
+
+def test_archives_posts_url():
+    """Test that the URL is correctly set when ARCHIVES_PATH_ENABLED is True."""
+    # Check default settings
+    assert settings.ARCHIVES_PATH_ENABLED is True
+    assert settings.ARCHIVES_PATH == "test-url-archives"
+
+    url = reverse("djpress:archives_posts", kwargs={"year": "2024"})
+    assert url == "/test-url-archives/2024/"
+
+
+@pytest.mark.urls("djpress.urls")
+def test_archives_posts_url_no_ARCHIVES_PATH_ENABLED():
+    """Test that the URL is correctly set when ARCHIVES_PATH_ENABLED is True."""
+    # Check default settings
+    assert settings.ARCHIVES_PATH_ENABLED is True
+    assert settings.ARCHIVES_PATH == "test-url-archives"
+
+    settings.set("ARCHIVES_PATH_ENABLED", False)
+    assert settings.ARCHIVES_PATH_ENABLED is False
+
+    # Clear the URL caches
+    clear_url_caches()
+
+    # Reload the URL module to reflect the changed settings
+    importlib.reload(djpress_urls)
+
+    # Try to reverse the URL and check if it's not registered
+    with pytest.raises(NoReverseMatch):
+        reverse("djpress:archives_posts", kwargs={"year": "2024"})
+
+    # Set back to default value
+    settings.set("ARCHIVES_PATH_ENABLED", True)
+    assert settings.ARCHIVES_PATH_ENABLED is True
+
+
+def test_rss_feed_url():
+    """Test that the URL is correctly set when RSS_ENABLED is True."""
+    # Check default settings
+    assert settings.RSS_ENABLED is True
+    assert settings.RSS_PATH == "test-rss"
+
+    url = reverse("djpress:rss_feed")
+    assert url == "/test-rss/"
+
+
+@pytest.mark.urls("djpress.urls")
+def test_rss_feed_url_no_RSS_ENABLED():
+    """Test that the URL is correctly set when RSS_ENABLED is True."""
+    # Check default settings
+    assert settings.RSS_ENABLED is True
+    assert settings.RSS_PATH == "test-rss"
+
+    settings.set("RSS_ENABLED", False)
+    assert settings.RSS_ENABLED is False
+
+    # Clear the URL caches
+    clear_url_caches()
+
+    # Reload the URL module to reflect the changed settings
+    importlib.reload(djpress_urls)
+
+    # Try to reverse the URL and check if it's not registered
+    with pytest.raises(NoReverseMatch):
+        reverse("djpress:rss_feed")
+
+    # Set back to default value
+    settings.set("RSS_ENABLED", True)
+    assert settings.RSS_ENABLED is True

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -33,19 +33,13 @@ def test_regex_archives():
     assert settings.APPEND_SLASH is True
 
     # Test that the URL is correctly set
-    assert (
-        regex_archives()
-        == r"(?P<year>\d{4})(?:/(?P<month>\d{2})(?:/(?P<day>\d{2}))?)?/$"
-    )
+    assert regex_archives() == r"(?P<year>\d{4})(?:/(?P<month>\d{2})(?:/(?P<day>\d{2}))?)?/$"
 
     settings.set("APPEND_SLASH", False)
     assert settings.APPEND_SLASH is False
 
     # Test that the URL is correctly set
-    assert (
-        regex_archives()
-        == r"(?P<year>\d{4})(?:/(?P<month>\d{2})(?:/(?P<day>\d{2}))?)?$"
-    )
+    assert regex_archives() == r"(?P<year>\d{4})(?:/(?P<month>\d{2})(?:/(?P<day>\d{2}))?)?$"
 
     # Set back to default value
     settings.set("APPEND_SLASH", True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,10 @@ from djpress.utils import get_author_display_name, render_markdown, get_template
 from django.contrib.auth.models import User
 from django.template.loader import TemplateDoesNotExist
 
+from djpress.utils import extract_parts_from_path
+from djpress.conf import settings
+from djpress.exceptions import SlugNotFoundError
+
 
 # create a parameterized fixture for a test user with first name, last name, and username
 @pytest.fixture(
@@ -66,27 +70,17 @@ def test_render_markdown_link():
 
 
 def test_render_markdown_link_with_title():
-    markdown_text = (
-        '[DJ Press](https://github.com/stuartmaxwell/djpress/ "DJ Press GitHub")'
-    )
+    markdown_text = '[DJ Press](https://github.com/stuartmaxwell/djpress/ "DJ Press GitHub")'
     html = render_markdown(markdown_text)
 
-    assert (
-        '<a href="https://github.com/stuartmaxwell/djpress/" title="DJ Press GitHub">DJ Press</a>'
-        in html
-    )
+    assert '<a href="https://github.com/stuartmaxwell/djpress/" title="DJ Press GitHub">DJ Press</a>' in html
 
 
 def test_render_markdown_image():
-    markdown_text = (
-        "![DJ Press Logo](https://github.com/stuartmaxwell/djpress/logo.png)"
-    )
+    markdown_text = "![DJ Press Logo](https://github.com/stuartmaxwell/djpress/logo.png)"
     html = render_markdown(markdown_text)
 
-    assert (
-        '<img alt="DJ Press Logo" src="https://github.com/stuartmaxwell/djpress/logo.png">'
-        in html
-    )
+    assert '<img alt="DJ Press Logo" src="https://github.com/stuartmaxwell/djpress/logo.png">' in html
 
 
 def test_render_markdown_image_with_title():
@@ -115,3 +109,214 @@ def test_get_template_name():
     ]
     with pytest.raises(TemplateDoesNotExist):
         get_template_name(templates)
+
+
+def test_extract_slug_from_path_prefix_testing():
+    # Confirm settings are set according to settings_testing.py
+    assert settings.POST_PREFIX == "test-posts"
+    assert settings.POST_PERMALINK == ""
+
+    # Test case 1 - path with slug
+    path = "test-posts/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "slug"
+
+    # Test case 2 - post prefix missing
+    path = "/slug"
+    # Should raise an exception
+    with pytest.raises(SlugNotFoundError):
+        path_parts = extract_parts_from_path(path)
+
+    # Test case 3 - post prefix incorrect
+    path = "foobar/slug"
+    # Should raise an exception
+    with pytest.raises(SlugNotFoundError):
+        path_parts = extract_parts_from_path(path)
+
+    # Test case 4 - path with slug and post permalink
+    path = "test-posts/2024/01/01/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "2024/01/01/slug"
+
+    # Test case 5 - post permalink but no slug
+    path = "test-posts/"
+    # Should raise an exception
+    with pytest.raises(SlugNotFoundError):
+        path_parts = extract_parts_from_path(path)
+
+    # Remove the post prefix
+    settings.POST_PREFIX = ""
+    assert settings.POST_PREFIX == ""
+
+    # Test case 5 - just a slug
+    path = "slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "slug"
+
+    # Test case 6 - slug with post prefix
+    path = "test-posts/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "test-posts/slug"
+
+    # Test case 7 - path with slug and post permalink
+    path = "2024/01/01/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "2024/01/01/slug"
+
+    # Set the post prefix back to "test-posts"
+    settings.POST_PREFIX = "test-posts"
+
+    # Confirm settings are set according to settings_testing.py
+    assert settings.POST_PREFIX == "test-posts"
+    assert settings.POST_PERMALINK == ""
+
+
+def test_extract_slug_from_path_permalink_testing():
+    # Confirm settings are set according to settings_testing.py
+    assert settings.POST_PREFIX == "test-posts"
+    assert settings.POST_PERMALINK == ""
+
+    # Test case 1 - slug with prefix and no permalink
+    path = "test-posts/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "slug"
+
+    # Set the post permalink to "%Y/%m/%d"
+    settings.POST_PERMALINK = "%Y/%m/%d"
+    assert settings.POST_PREFIX == "test-posts"
+    assert settings.POST_PERMALINK == "%Y/%m/%d"
+
+    # Test case 2 - slug with prefix and permalink
+    path = "test-posts/2024/01/01/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "slug"
+
+    # Test case 3 - slug with extra date parts
+    path = "test-posts/2024/01/01/01/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "01/slug"
+
+    # Test case 4 - slugn with missing date parts
+    path = "test-posts/2024/01/slug"
+    # Should raise an exception
+    with pytest.raises(SlugNotFoundError):
+        path_parts = extract_parts_from_path(path)
+
+    # Test case 5 - missing slug
+    path = "test-posts/2024/01/01"
+    # Should raise an exception
+    with pytest.raises(SlugNotFoundError):
+        path_parts = extract_parts_from_path(path)
+
+    # Set the post permalink to "%Y/%m"
+    settings.POST_PERMALINK = "%Y/%m"
+    assert settings.POST_PREFIX == "test-posts"
+    assert settings.POST_PERMALINK == "%Y/%m"
+
+    # Test case 6 - slug with prefix and permalink
+    path = "test-posts/2024/01/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "slug"
+
+    # Test case 7 - slug with extra date parts
+    path = "test-posts/2024/01/01/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "01/slug"
+
+    # Test case 8 - slug with missing date parts
+    path = "test-posts/2024/slug"
+    # Should raise an exception
+    with pytest.raises(SlugNotFoundError):
+        path_parts = extract_parts_from_path(path)
+
+    # Test case 9 - missing slug
+    path = "test-posts/2024/01"
+    # Should raise an exception
+    with pytest.raises(SlugNotFoundError):
+        path_parts = extract_parts_from_path(path)
+
+    # Set the post permalink to default
+    settings.POST_PERMALINK = ""
+
+    # Confirm settings are set according to settings_testing.py
+    assert settings.POST_PREFIX == "test-posts"
+    assert settings.POST_PERMALINK == ""
+
+
+def test_extract_date_parts_from_path():
+    # Confirm settings are set according to settings_testing.py
+    assert settings.POST_PREFIX == "test-posts"
+    assert settings.POST_PERMALINK == ""
+
+    # Set the post permalink to "%Y/%m/%d"
+    settings.POST_PERMALINK = "%Y/%m/%d"
+    assert settings.POST_PREFIX == "test-posts"
+    assert settings.POST_PERMALINK == "%Y/%m/%d"
+
+    # Test case 1 - slug with prefix and permalink
+    path = "test-posts/2024/01/01/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "slug"
+    assert path_parts.year == 2024
+    assert path_parts.month == 1
+    assert path_parts.day == 1
+
+    # Test case 2 - slug with extra date parts
+    path = "test-posts/2024/01/01/01/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "01/slug"
+    assert path_parts.year == 2024
+    assert path_parts.month == 1
+    assert path_parts.day == 1
+
+    # Test case 3 - slug with missing date parts
+    path = "test-posts/2024/01/slug"
+    # Should raise an exception
+    with pytest.raises(SlugNotFoundError):
+        path_parts = extract_parts_from_path(path)
+
+    # Test case 4 - missing slug
+    path = "test-posts/2024/01/01"
+    # Should raise an exception
+    with pytest.raises(SlugNotFoundError):
+        path_parts = extract_parts_from_path(path)
+
+    # Set the post permalink to "%Y/%m"
+    settings.POST_PERMALINK = "%Y/%m"
+    assert settings.POST_PREFIX == "test-posts"
+    assert settings.POST_PERMALINK == "%Y/%m"
+
+    # Test case 5 - slug with prefix and permalink
+    path = "test-posts/2024/01/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "slug"
+    assert path_parts.year == 2024
+    assert path_parts.month == 1
+    assert path_parts.day is None
+
+    # Test case 6 - slug with extra date parts
+    path = "test-posts/2024/01/01/slug"
+    path_parts = extract_parts_from_path(path)
+    assert path_parts.slug == "01/slug"
+    assert path_parts.year == 2024
+    assert path_parts.month == 1
+    assert path_parts.day is None
+
+    # Test case 7 - slug with missing date parts
+    path = "test-posts/2024/slug"
+    # Should raise an exception
+    with pytest.raises(SlugNotFoundError):
+        path_parts = extract_parts_from_path(path)
+
+    # Test case 8 - missing slug
+    path = "test-posts/2024/01"
+    # Should raise an exception
+    with pytest.raises(SlugNotFoundError):
+        path_parts = extract_parts_from_path(path)
+
+    # Set the post permalink to default
+    settings.POST_PERMALINK = ""
+
+    # Confirm settings are set according to settings_testing.py
+    assert settings.POST_PREFIX == "test-posts"
+    assert settings.POST_PERMALINK == ""

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -182,7 +182,7 @@ def test_date_archives_year(client, test_post1):
 
 @pytest.mark.django_db
 def test_date_archives_year_invalid_year(client):
-    response = client.get("/archives/0000/")
+    response = client.get("/test-url-archives/0000/")
     assert response.status_code == 400
 
 
@@ -209,9 +209,9 @@ def test_date_archives_month(client, test_post1):
 
 @pytest.mark.django_db
 def test_date_archives_month_invalid_month(client):
-    response1 = client.get("/archives/2024/00/")
+    response1 = client.get("/test-url-archives/2024/00/")
     assert response1.status_code == 400
-    response2 = client.get("/archives/2024/13/")
+    response2 = client.get("/test-url-archives/2024/13/")
     assert response2.status_code == 400
 
 
@@ -239,9 +239,9 @@ def test_date_archives_day(client, test_post1):
 
 @pytest.mark.django_db
 def test_date_archives_day_invalid_day(client):
-    response1 = client.get("/archives/2024/01/00/")
+    response1 = client.get("/test-url-archives/2024/01/00/")
     assert response1.status_code == 400
-    response2 = client.get("/archives/2024/01/32/")
+    response2 = client.get("/test-url-archives/2024/01/32/")
     assert response2.status_code == 400
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -228,9 +228,7 @@ def test_date_archives_month_no_posts(client, test_post1):
 
 @pytest.mark.django_db
 def test_date_archives_day(client, test_post1):
-    url = reverse(
-        "djpress:archives_posts", kwargs={"year": "2024", "month": "01", "day": "01"}
-    )
+    url = reverse("djpress:archives_posts", kwargs={"year": "2024", "month": "01", "day": "01"})
     response = client.get(url)
     assert response.status_code == 200
     assert "posts" in response.context
@@ -247,9 +245,7 @@ def test_date_archives_day_invalid_day(client):
 
 @pytest.mark.django_db
 def test_date_archives_day_no_posts(client, test_post1):
-    url = reverse(
-        "djpress:archives_posts", kwargs={"year": "2024", "month": "01", "day": "02"}
-    )
+    url = reverse("djpress:archives_posts", kwargs={"year": "2024", "month": "01", "day": "02"})
     response = client.get(url)
     assert response.status_code == 200
     assert not test_post1.title.encode() in response.content

--- a/uv.lock
+++ b/uv.lock
@@ -14,24 +14,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cachetools"
-version = "5.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/38/a0f315319737ecf45b4319a8cd1f3a908e29d9277b46942263292115eee7/cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a", size = 27661 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292", size = 9524 },
-]
-
-[[package]]
-name = "chardet"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -100,15 +82,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distlib"
-version = "0.3.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/91/e2df406fb4efacdf46871c25cde65d3c6ee5e173b7e5a4547a47bae91920/distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64", size = 609931 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/41/9307e4f5f9976bc8b7fea0b66367734e8faf3ec84bc0d412d8cfabbb66cd/distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784", size = 468850 },
-]
-
-[[package]]
 name = "django"
 version = "5.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -148,32 +121,20 @@ dependencies = [
 [package.optional-dependencies]
 test = [
     { name = "coverage" },
+    { name = "django-debug-toolbar" },
     { name = "pytest" },
     { name = "pytest-django" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "coverage" },
-    { name = "django-debug-toolbar" },
-    { name = "tox-uv" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "coverage", marker = "extra == 'test'", specifier = ">=7.6.1" },
     { name = "django" },
+    { name = "django-debug-toolbar", marker = "extra == 'test'", specifier = ">=4.4.0" },
     { name = "markdown" },
     { name = "pygments" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.3" },
     { name = "pytest-django", marker = "extra == 'test'", specifier = ">=4.9.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "coverage", specifier = ">=7.6.1" },
-    { name = "django-debug-toolbar", specifier = ">=4.4.0" },
-    { name = "tox-uv", specifier = ">=1.11.3" },
 ]
 
 [[package]]
@@ -183,15 +144,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453 },
-]
-
-[[package]]
-name = "filelock"
-version = "3.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/76/3981447fd369539aba35797db99a8e2ff7ed01d9aa63e9344a31658b8d81/filelock-3.16.0.tar.gz", hash = "sha256:81de9eb8453c769b63369f87f11131a7ab04e367f8d97ad39dc230daa07e3bec", size = 18008 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/95/f9310f35376024e1086c59cbb438d319fc9a4ef853289ce7c661539edbd4/filelock-3.16.0-py3-none-any.whl", hash = "sha256:f6ed4c963184f4c84dd5557ce8fece759a3724b37b80c6c4f20a2f63a4dc6609", size = 16170 },
 ]
 
 [[package]]
@@ -222,15 +174,6 @@ wheels = [
 ]
 
 [[package]]
-name = "platformdirs"
-version = "4.3.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/19/f7bee3a71decedd8d7bc4d3edb7970b8e899f3caef257b0f0d623f2f7b11/platformdirs-4.3.3.tar.gz", hash = "sha256:d4e0b7d8ec176b341fb03cb11ca12d0276faa8c485f9cd218f613840463fc2c0", size = 21304 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/e6/7c8e8c326903bd97c6c0c47e0a3c5de815faaae986cab7defdeddf5fddcd/platformdirs-4.3.3-py3-none-any.whl", hash = "sha256:50a5450e2e84f44539718293cbb1da0a0885c9d14adf21b77bae4e66fc99d9b5", size = 18437 },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -246,19 +189,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
-]
-
-[[package]]
-name = "pyproject-api"
-version = "1.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/41/43/5581b42a96c5ee7bf2b22d3b08b34c8a54dfe6591d8b9a4314c890bd4a0d/pyproject_api-1.7.1.tar.gz", hash = "sha256:7ebc6cd10710f89f4cf2a2731710a98abce37ebff19427116ff2174c9236a827", size = 22271 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/88/c1451b66664ae596bae93928ff372f4da89c2c7250132ecb76cc99256c93/pyproject_api-1.7.1-py3-none-any.whl", hash = "sha256:2dc1654062c2b27733d8fd4cdda672b22fe8741ef1dde8e3a998a9547b071eeb", size = 13172 },
 ]
 
 [[package]]
@@ -309,41 +239,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tox"
-version = "4.18.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cachetools" },
-    { name = "chardet" },
-    { name = "colorama" },
-    { name = "filelock" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "pluggy" },
-    { name = "pyproject-api" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/cc/272e73f90be0f6df89efaf82e5d804b90b4e39ceb0ef1621486bb0e921e8/tox-4.18.1.tar.gz", hash = "sha256:3c0c96bc3a568a5c7e66387a4cfcf8c875b52e09f4d47c9f7a277ec82f1a0b11", size = 181159 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/59/a2ae6f32771cd3de2000618d77b8f77502da822a141e2c797fa4af38a701/tox-4.18.1-py3-none-any.whl", hash = "sha256:35d472032ee1f73fe20c3e0e73d7073a4e85075c86ff02c576f9fc7c6a15a578", size = 156796 },
-]
-
-[[package]]
-name = "tox-uv"
-version = "1.11.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "tox" },
-    { name = "uv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/b2/d441179ca3f5f3180844a647ebf9d9bbdfda24493e5220225ff6d039c32b/tox_uv-1.11.3.tar.gz", hash = "sha256:316f559ae5525edec12791d9e1f393e405ded5b7e7d50fbaee4726676951f49a", size = 13666 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/88/a6d7ccddb0da225ac636ba24822ea856ce893f5bfbaaf23165f1bc01d310/tox_uv-1.11.3-py3-none-any.whl", hash = "sha256:d434787406ff2854600c1ceaa555519080026208cf7f65bb5d4b2d7c9c4776de", size = 11276 },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -359,43 +254,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/74/5b/e025d02cb3b66b7b76093404392d4b44343c69101cc85f4d180dd5784717/tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd", size = 190559 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/58/f9c9e6be752e9fcb8b6a0ee9fb87e6e7a1f6bcab2cdc73f02bb7ba91ada0/tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252", size = 345370 },
-]
-
-[[package]]
-name = "uv"
-version = "0.4.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/bf/5b426cfd6c3d0b327d06afc16599ec41c99ee3c4d845ee627099cf1a72f8/uv-0.4.10.tar.gz", hash = "sha256:2ff29a2f55a697e78d787a41ab41d4b26421d200728289b88b6241d3b486c436", size = 1891876 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/dc/789692a8fda886c6b3fffc354d2af60978fb091d48209839a7268af8a31f/uv-0.4.10-py3-none-linux_armv6l.whl", hash = "sha256:99954a94dd6c4bff8a9a963c05bc3988214ea39e7511a52fda35112e1a478447", size = 11479241 },
-    { url = "https://files.pythonhosted.org/packages/60/5a/6bff6e5ec5831c9470adfa5d4e3de4a914374a77f6335e482fa46b19d9b9/uv-0.4.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bc87d6c581cfed0979e0f5ee93383d46006c6d4a5e4eb9f43ef13bce61b50cc2", size = 11709579 },
-    { url = "https://files.pythonhosted.org/packages/83/07/95096f172a43151c7a27e9d1a7d94f2e33b1204f3470a46bd18af5835c0d/uv-0.4.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0f8b9ba4ecfbea343a00e46d509669606e55fe233d800752c4c25650473df358", size = 10862040 },
-    { url = "https://files.pythonhosted.org/packages/55/2a/d1b9b1506158ba4dd711cd48d1d6ce931a98557836eecd0f20d03635d860/uv-0.4.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:a9dc1f8fca5c4a2f73054d9f56c7397e9fc6ba43baefc503d6f0128d72ea662f", size = 11199902 },
-    { url = "https://files.pythonhosted.org/packages/49/a0/1210957c6aeeb13b0d4bbc8515969e7df34ceb193df4965872fbac665537/uv-0.4.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:30d1f8348a2b18e21a35c97ce42528781f242d0303881fc92fbacdcb653c8bca", size = 11269050 },
-    { url = "https://files.pythonhosted.org/packages/94/ec/b0a3cb548fd5200ddfc84a46deb281192347a4ff47ee4b90c67a0a30979a/uv-0.4.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b89dfd213359a23797155ff8175e5202ed6b84aadeb20df92132127608d46acf", size = 11877390 },
-    { url = "https://files.pythonhosted.org/packages/b0/ff/2a72772622f0f24321b137444cb084b3bdc82d726cde539fbade4605eb7e/uv-0.4.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e99e3f761875962942e0743b868bd666021d5e14c3df494e820ef8f45fb88578", size = 12664737 },
-    { url = "https://files.pythonhosted.org/packages/90/f7/4e771e65250cef43864eb5869fa289cfc8cd0324f07c06937e37346ec2b5/uv-0.4.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3be73788db9ceacb94a521cf67ca5cc08bac512aef71145b904ab62a3acabdae", size = 12410948 },
-    { url = "https://files.pythonhosted.org/packages/42/c2/143e811303447a4452c9897a2013e32d111b5bc70dfd66a0ff484b5bf06b/uv-0.4.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6ba1cc3070e5c63ce0a1421fbed28bd1b3ff520671d7badda11a501504c78394", size = 15892011 },
-    { url = "https://files.pythonhosted.org/packages/ff/ac/957c277762c47f375c2a1731e591084d0657dda3df6edc256178f7d4b45a/uv-0.4.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b6b6c6b8cc0c4e54ab25e3b46e49d1e583e26c194572eb42bfeebf71b39cca2", size = 12186373 },
-    { url = "https://files.pythonhosted.org/packages/ba/f7/002b5a17e9ab27f2c5f57ef044dbfee99033dc00739e6df0ca3891bcff97/uv-0.4.10-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:bc99e6b45303f0881a8dc199f0b7ea8261dd1779e576e8477a7721ceeeaafcc7", size = 11341756 },
-    { url = "https://files.pythonhosted.org/packages/de/d7/8d00dc10f7fe4912b496c054d910292f797b64302318e558f2bb94a29ac6/uv-0.4.10-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:1ff5130b6f3af79c4e47f63db03215aed15e78cb4f1f51682af6f9949c2bcf00", size = 11129951 },
-    { url = "https://files.pythonhosted.org/packages/0b/da/564711d76819bae3cea042ff75c6348b6d302ab7a1d02b6848dbbfefe94d/uv-0.4.10-py3-none-musllinux_1_1_i686.whl", hash = "sha256:8fa510dfbbde4f8ad5cd2769568c7b0c3e867b74deaf4beabcca79e74e7550cc", size = 11686193 },
-    { url = "https://files.pythonhosted.org/packages/2d/2c/b3998dd4e4413d44c09dc7acba44bc116c978ac345d24eb1c7a4adbceea7/uv-0.4.10-py3-none-musllinux_1_1_ppc64le.whl", hash = "sha256:444e1cdb36d7ef103e52185f918800527c255dc369c9f90eb1f198dfa3f4d5bc", size = 13453677 },
-    { url = "https://files.pythonhosted.org/packages/04/8a/3313ce320024da059d7624b7ab39251d6da4caf067359797abb0c3afe5cf/uv-0.4.10-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:97a1187e11a9df70d55bc577721ad4a19441cda56e4d69fb2f38d88c7650d2a0", size = 12300196 },
-    { url = "https://files.pythonhosted.org/packages/a4/24/8b45f4129fdc3b8072db213418692f36e80a9d6542e761b6077fa4325762/uv-0.4.10-py3-none-win32.whl", hash = "sha256:0784f75093a75390d8d480cc8a444516e78f08849db9a13c21791a5f651df4a1", size = 11594212 },
-    { url = "https://files.pythonhosted.org/packages/1b/93/44be9610ff870127f0500d5b36e98b823aebb3fa7a8addbfa91ed1aeb715/uv-0.4.10-py3-none-win_amd64.whl", hash = "sha256:ff9046a8c5e836e892ac7741e672ee016e92e55c659fa8195595df65a1f3accf", size = 12842773 },
-]
-
-[[package]]
-name = "virtualenv"
-version = "20.26.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/84/8a/134f65c3d6066153b84fc176c58877acd8165ed0b79a149ff50502597284/virtualenv-20.26.4.tar.gz", hash = "sha256:c17f4e0f3e6036e9f26700446f85c76ab11df65ff6d8a9cbfad9f71aabfcf23c", size = 9385017 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/ea/12f774a18b55754c730c8383dad8f10d7b87397d1cb6b2b944c87381bb3b/virtualenv-20.26.4-py3-none-any.whl", hash = "sha256:48f2695d9809277003f30776d155615ffc11328e6a0a8c1f0ec80188d7874a55", size = 6013327 },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -147,6 +147,7 @@ dependencies = [
 
 [package.optional-dependencies]
 test = [
+    { name = "coverage" },
     { name = "pytest" },
     { name = "pytest-django" },
 ]
@@ -160,6 +161,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "coverage", marker = "extra == 'test'", specifier = ">=7.6.1" },
     { name = "django" },
     { name = "markdown" },
     { name = "pygments" },


### PR DESCRIPTION
Initial release that supports dates in permalinks. This feature is not finished yet since it still requires a unique slug. When retrieving posts from the database, the date is ignored. For example, both of these will return the same content (assuming `test-post` exists):

- /post/2024/01/01/test-post
- /post/202409/24/test-post

But, for now we can change the URL structure to include permalinks.