### PR TITLE
Update djpress to version 0.16.0b0 with metadata enhancements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ omit = ["*/tests/*", "*/migrations/*"]
 
 [tool.bumpver]
 current_version = "0.15.3"
-version_pattern = "MAJOR.MINOR.PATCH"
+version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "👍 bump version {old_version} -> {new_version}"
 commit = true
 push = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "djpress"
-version = "0.15.3"
+version = "0.16.0b0"
 description = "A blog application for Django sites, inspired by classic WordPress."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -101,7 +101,7 @@ include = ["src/djpress/*"]
 omit = ["*/tests/*", "*/migrations/*"]
 
 [tool.bumpver]
-current_version = "0.15.3"
+current_version = "0.16.0b0"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "👍 bump version {old_version} -> {new_version}"
 commit = true

--- a/src/djpress/__init__.py
+++ b/src/djpress/__init__.py
@@ -1,3 +1,3 @@
 """djpress module."""
 
-__version__ = "0.15.3"
+__version__ = "0.16.0b0"

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -330,7 +331,7 @@ wheels = [
 
 [[package]]
 name = "djpress"
-version = "0.15.3"
+version = "0.16.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -382,6 +383,7 @@ requires-dist = [
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5.2" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=3.0.1" },
 ]
+provides-extras = ["test", "docs"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "bumpver", specifier = ">=2024.1130" }]


### PR DESCRIPTION
Bump the version of djpress to 0.16.0b0, update the version pattern in the configuration, and add revision and extras metadata in the lock file.