### PR TITLE
Add tag permissions to user groups and bump version to 0.16.0b1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "djpress"
-version = "0.16.0b0"
+version = "0.16.0b1"
 description = "A blog application for Django sites, inspired by classic WordPress."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -101,7 +101,7 @@ include = ["src/djpress/*"]
 omit = ["*/tests/*", "*/migrations/*"]
 
 [tool.bumpver]
-current_version = "0.16.0b0"
+current_version = "0.16.0b1"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "👍 bump version {old_version} -> {new_version}"
 commit = true

--- a/src/djpress/__init__.py
+++ b/src/djpress/__init__.py
@@ -1,3 +1,3 @@
 """djpress module."""
 
-__version__ = "0.16.0b0"
+__version__ = "0.16.0b1"

--- a/src/djpress/signals.py
+++ b/src/djpress/signals.py
@@ -44,16 +44,24 @@ def create_groups(sender: AppConfig, **_) -> None:  # noqa: ANN003
         content_type=category_content_type,
         codename__in=["add_category", "change_category", "delete_category"],
     )
+    tag_permissions = Permission.objects.filter(
+        content_type=ContentType.objects.get_for_model(Tag),
+        codename__in=["add_tag", "change_tag", "delete_tag"],
+    )
+    tag_add_permission = Permission.objects.get(
+        content_type=ContentType.objects.get_for_model(Tag),
+        codename="add_tag",
+    )
 
     # Create groups and assign permissions
     editor_group, _ = Group.objects.get_or_create(name="editor")
-    editor_group.permissions.add(publish_permission, *standard_permissions, *category_permissions)
+    editor_group.permissions.add(publish_permission, *standard_permissions, *category_permissions, *tag_permissions)
 
     author_group, _ = Group.objects.get_or_create(name="author")
-    author_group.permissions.add(publish_permission, *standard_permissions)
+    author_group.permissions.add(publish_permission, *standard_permissions, tag_add_permission)
 
     contributor_group, _ = Group.objects.get_or_create(name="contributor")
-    contributor_group.permissions.add(*standard_permissions)
+    contributor_group.permissions.add(*standard_permissions, tag_add_permission)
 
 
 @receiver(post_save, sender=Category)

--- a/uv.lock
+++ b/uv.lock
@@ -331,7 +331,7 @@ wheels = [
 
 [[package]]
 name = "djpress"
-version = "0.16.0b0"
+version = "0.16.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Introduce tag permissions for user groups in signals.py and update the version of djpress to 0.16.0b1.