### PR TITLE
Update .gitignore and enhance regex_category documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache

--- a/src/djpress/url_utils.py
+++ b/src/djpress/url_utils.py
@@ -129,16 +129,16 @@ def regex_page() -> str:
 
 
 def regex_category() -> str:
-    """Generate the regex path for the category view."""
+    """Generate the regex path for the category view.
+
+    The category URL must have the CATEGORY_PREFIX. If not, an error occurs on startup: E002. See conf.py for details.
+    """
     # Regex explanation:
     # - (?P<slug>[\w-]+): This is a named capture group that matches any word character (alphanumeric or underscore)
     #   or a hyphen.
     regex = r"(?P<slug>[\w-]+)"
 
-    if djpress_settings.CATEGORY_PREFIX:
-        regex = rf"{re.escape(djpress_settings.CATEGORY_PREFIX)}/{regex}"
-
-    return regex
+    return rf"{re.escape(djpress_settings.CATEGORY_PREFIX)}/{regex}"
 
 
 def regex_tag() -> str:

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -189,15 +189,6 @@ def test_category_with_prefix(settings):
 
 
 @pytest.mark.django_db
-def test_category_empty_prefix(settings):
-    settings.DJPRESS_SETTINGS["CATEGORY_PREFIX"] = ""
-    expected_regex = r"(?P<slug>[\w-]+)"
-
-    regex = regex_category()
-    assert regex == expected_regex
-
-
-@pytest.mark.django_db
 def test_author_with_prefix(settings):
     settings.DJPRESS_SETTINGS["AUTHOR_PREFIX"] = "author"
     expected_regex = r"author/(?P<author>[\w-]+)"


### PR DESCRIPTION
Add `.nox/` to `.gitignore` to exclude Nox virtual environments and improve the documentation for the `regex_category` function, clarifying the requirement for the `CATEGORY_PREFIX`. Simplify the regex construction for better readability.

Fixes #107