### PR TITLE
Remove permalink from Category model and improve URL generation

### DIFF
--- a/src/djpress/models/category.py
+++ b/src/djpress/models/category.py
@@ -99,14 +99,6 @@ class Category(models.Model):
             raise ValueError(msg) from exc
 
     @property
-    def permalink(self: "Category") -> str:
-        """Return the category's permalink."""
-        if djpress_settings.CATEGORY_ENABLED and djpress_settings.CATEGORY_PREFIX:
-            return f"{djpress_settings.CATEGORY_PREFIX}/{self.slug}"
-
-        return f"{self.slug}"
-
-    @property
     def url(self) -> str:
         """Return the category's URL."""
         from djpress.url_utils import get_category_url

--- a/src/djpress/url_utils.py
+++ b/src/djpress/url_utils.py
@@ -232,10 +232,10 @@ def get_category_url(category: "Category") -> str:
 
 def get_tag_url(tag: "Tag") -> str:
     """Return the URL for a single tag."""
-    if djpress_settings.TAG_ENABLED and djpress_settings.TAG_PREFIX:
+    if djpress_settings.TAG_ENABLED and djpress_settings.TAG_PREFIX != "":
         url = f"/{djpress_settings.TAG_PREFIX}/{tag.slug}"
     else:
-        url = f"/{tag.slug}"
+        url = ""
 
     if django_settings.APPEND_SLASH:
         return f"{url}/"

--- a/src/djpress/url_utils.py
+++ b/src/djpress/url_utils.py
@@ -219,7 +219,7 @@ def get_category_url(category: "Category") -> str:
 
     If either djpress_settings.CATEGORY_ENABLED or djpress_settings.CATEGORY_PREFIX is not set, return an empty string.
     """
-    if djpress_settings.CATEGORY_ENABLED and djpress_settings.CATEGORY_PREFIX:
+    if djpress_settings.CATEGORY_ENABLED and djpress_settings.CATEGORY_PREFIX != "":
         url = f"/{djpress_settings.CATEGORY_PREFIX}/{category.slug}"
     else:
         url = ""

--- a/src/djpress/url_utils.py
+++ b/src/djpress/url_utils.py
@@ -215,8 +215,14 @@ def get_author_url(user: User) -> str:
 
 
 def get_category_url(category: "Category") -> str:
-    """Return the URL for the category."""
-    url = f"/{category.permalink}"
+    """Return the URL for the category.
+
+    If either djpress_settings.CATEGORY_ENABLED or djpress_settings.CATEGORY_PREFIX is not set, return an empty string.
+    """
+    if djpress_settings.CATEGORY_ENABLED and djpress_settings.CATEGORY_PREFIX:
+        url = f"/{djpress_settings.CATEGORY_PREFIX}/{category.slug}"
+    else:
+        url = ""
 
     if django_settings.APPEND_SLASH:
         return f"{url}/"

--- a/tests/test_models_category.py
+++ b/tests/test_models_category.py
@@ -155,24 +155,6 @@ def test_get_category_by_slug_not_exists(settings):
 
 
 @pytest.mark.django_db
-def test_category_permalink(settings):
-    """Test that the permalink property returns the correct URL."""
-    # Confirm the settings in settings_testing.py
-    assert settings.DJPRESS_SETTINGS["CACHE_CATEGORIES"] is True
-    assert settings.DJPRESS_SETTINGS["CATEGORY_ENABLED"] is True
-    assert settings.DJPRESS_SETTINGS["CATEGORY_PREFIX"] == "test-url-category"
-
-    category = Category.objects.create(title="Test Category", slug="test-category")
-
-    assert category.permalink == "test-url-category/test-category"
-
-    settings.DJPRESS_SETTINGS["CATEGORY_ENABLED"] = False
-    settings.DJPRESS_SETTINGS["CATEGORY_PREFIX"] = ""
-
-    assert category.permalink == "test-category"
-
-
-@pytest.mark.django_db
 def test_category_posts(test_post1, test_post2, category1, category2):
     assert list(category1.posts.all()) == [test_post1]
     assert list(category2.posts.all()) == [test_post2]

--- a/tests/test_models_tag.py
+++ b/tests/test_models_tag.py
@@ -169,7 +169,7 @@ def test_get_tag_by_slug_not_exists(settings):
 
 
 @pytest.mark.django_db
-def test_category_url(settings):
+def test_tag_url(settings):
     """Test that the url property returns the correct URL."""
     # Confirm the settings in settings_testing.py
     assert settings.DJPRESS_SETTINGS["TAG_ENABLED"] is True
@@ -182,7 +182,7 @@ def test_category_url(settings):
     settings.DJPRESS_SETTINGS["TAG_ENABLED"] = False
     settings.DJPRESS_SETTINGS["TAG_PREFIX"] = ""
 
-    assert tag.url == "/test-tag/"
+    assert tag.url == "/"
 
 
 @pytest.mark.django_db

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -299,13 +299,14 @@ def test_get_author_url(settings, user):
 @pytest.mark.django_db
 def test_get_category_url(settings, category1):
     assert settings.APPEND_SLASH is True
-    expected_url = f"/{category1.permalink}/"
+    category_prefix = settings.DJPRESS_SETTINGS["CATEGORY_PREFIX"]
+    expected_url = f"/{category_prefix}/{category1.slug}/"
 
     url = get_category_url(category1)
     assert url == expected_url
 
     settings.APPEND_SLASH = False
-    expected_url = f"/{category1.permalink}"
+    expected_url = f"/{category_prefix}/{category1.slug}"
 
     url = get_category_url(category1)
     assert url == expected_url

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -330,13 +330,6 @@ def test_get_tag_url(settings, tag1):
     url = get_tag_url(tag1)
     assert url == expected_url
 
-    assert settings.APPEND_SLASH is True
-    settings.DJPRESS_SETTINGS["TAG_PREFIX"] = ""
-    assert settings.DJPRESS_SETTINGS["TAG_PREFIX"] == ""
-    expected_url = f"/{tag1.slug}/"
-    url = get_tag_url(tag1)
-    assert url == expected_url
-
     settings.APPEND_SLASH = False
     settings.DJPRESS_SETTINGS["TAG_PREFIX"] = "test-url-tag"
     assert settings.DJPRESS_SETTINGS["TAG_PREFIX"] == "test-url-tag"

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -313,6 +313,16 @@ def test_get_category_url(settings, category1):
 
 
 @pytest.mark.django_db
+def test_get_category_url_blank(settings, category1):
+    assert settings.APPEND_SLASH is True
+    settings.DJPRESS_SETTINGS["CATEGORY_PREFIX"] = ""
+    expected_url = "/"
+
+    url = get_category_url(category1)
+    assert url == expected_url
+
+
+@pytest.mark.django_db
 def test_get_tag_url(settings, tag1):
     assert settings.APPEND_SLASH is True
     assert settings.DJPRESS_SETTINGS["TAG_PREFIX"] == "test-url-tag"
@@ -331,6 +341,16 @@ def test_get_tag_url(settings, tag1):
     settings.DJPRESS_SETTINGS["TAG_PREFIX"] = "test-url-tag"
     assert settings.DJPRESS_SETTINGS["TAG_PREFIX"] == "test-url-tag"
     expected_url = f"/test-url-tag/{tag1.slug}"
+    url = get_tag_url(tag1)
+    assert url == expected_url
+
+
+@pytest.mark.django_db
+def test_get_tag_url_blank(settings, tag1):
+    assert settings.APPEND_SLASH is True
+    settings.DJPRESS_SETTINGS["TAG_PREFIX"] = ""
+    expected_url = "/"
+
     url = get_tag_url(tag1)
     assert url == expected_url
 


### PR DESCRIPTION
Eliminate the permalink property from the Category model and update the URL generation functions for categories and tags to handle cases where the CATEGORY_PREFIX and TAG_PREFIX are empty. Add tests to ensure correct behavior in these scenarios.

Fixes #84