### PR TITLE
Add media permissions to user groups and bump version to 0.17.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "djpress"
-version = "0.17.0"
+version = "0.17.1"
 description = "A blog application for Django sites, inspired by classic WordPress."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -102,7 +102,7 @@ include = ["src/djpress/*"]
 omit = ["*/tests/*", "*/migrations/*"]
 
 [tool.bumpver]
-current_version = "0.17.0"
+current_version = "0.17.1"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "👍 bump version {old_version} -> {new_version}"
 commit = true

--- a/src/djpress/__init__.py
+++ b/src/djpress/__init__.py
@@ -1,3 +1,3 @@
 """djpress module."""
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/src/djpress/signals.py
+++ b/src/djpress/signals.py
@@ -7,6 +7,7 @@ from django.core.cache import cache
 from django.db.models.signals import post_delete, post_migrate, post_save
 from django.dispatch import receiver
 
+from djpress.models import Media
 from djpress.models.category import (
     CATEGORY_CACHE_KEY,
     Category,
@@ -52,16 +53,26 @@ def create_groups(sender: AppConfig, **_) -> None:  # noqa: ANN003
         content_type=ContentType.objects.get_for_model(Tag),
         codename="add_tag",
     )
+    media_permissions = Permission.objects.filter(
+        content_type=ContentType.objects.get_for_model(Media),
+        codename__in=["add_media", "change_media", "delete_media"],
+    )
 
     # Create groups and assign permissions
     editor_group, _ = Group.objects.get_or_create(name="editor")
-    editor_group.permissions.add(publish_permission, *standard_permissions, *category_permissions, *tag_permissions)
+    editor_group.permissions.add(
+        publish_permission,
+        *standard_permissions,
+        *category_permissions,
+        *tag_permissions,
+        *media_permissions,
+    )
 
     author_group, _ = Group.objects.get_or_create(name="author")
-    author_group.permissions.add(publish_permission, *standard_permissions, tag_add_permission)
+    author_group.permissions.add(publish_permission, *standard_permissions, tag_add_permission, *media_permissions)
 
     contributor_group, _ = Group.objects.get_or_create(name="contributor")
-    contributor_group.permissions.add(*standard_permissions, tag_add_permission)
+    contributor_group.permissions.add(*standard_permissions, tag_add_permission, *media_permissions)
 
 
 @receiver(post_save, sender=Category)

--- a/uv.lock
+++ b/uv.lock
@@ -331,7 +331,7 @@ wheels = [
 
 [[package]]
 name = "djpress"
-version = "0.17.0"
+version = "0.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Introduce media permissions for user groups in signals and update the version from 0.17.0 to 0.17.1.