### PR TITLE
Refactor type hints in models and managers

### DIFF
--- a/src/djpress/apps.py
+++ b/src/djpress/apps.py
@@ -11,7 +11,7 @@ class DjpressConfig(AppConfig):
     name = "djpress"
     label = "djpress"
 
-    def ready(self: "DjpressConfig") -> None:
+    def ready(self) -> None:
         """Run when the app is ready."""
         # Import signals to ensure they are registered
         import djpress.signals  # noqa: F401

--- a/src/djpress/feeds.py
+++ b/src/djpress/feeds.py
@@ -19,15 +19,15 @@ class PostFeed(Feed):
     link = url_utils.get_rss_url()
     description = djpress_settings.SITE_DESCRIPTION
 
-    def items(self: "PostFeed") -> "models.QuerySet":
+    def items(self) -> "models.QuerySet":
         """Return the most recent posts."""
         return Post.post_objects.get_recent_published_posts()
 
-    def item_title(self: "PostFeed", item: Post) -> str:
+    def item_title(self, item: Post) -> str:
         """Return the title of the post."""
         return item.title
 
-    def item_description(self: "PostFeed", item: Post) -> str:
+    def item_description(self, item: Post) -> str:
         """Return the description of the post.
 
         This is taken from the truncated content of the post converted to HTML from
@@ -38,6 +38,6 @@ class PostFeed(Feed):
             description += f'<p><a href="{self.item_link(item)}">Read more</a></p>'
         return description
 
-    def item_link(self: "PostFeed", item: Post) -> str:
+    def item_link(self, item: Post) -> str:
         """Return the link to the post."""
         return item.url

--- a/src/djpress/models/category.py
+++ b/src/djpress/models/category.py
@@ -14,7 +14,7 @@ CATEGORY_CACHE_KEY = "categories"
 class CategoryManager(models.Manager):
     """Category manager."""
 
-    def get_categories(self: "CategoryManager") -> models.QuerySet:
+    def get_categories(self) -> models.QuerySet:
         """Return the queryset for categories.
 
         If CACHE_CATEGORIES is set to True, we return the cached queryset.
@@ -24,7 +24,7 @@ class CategoryManager(models.Manager):
 
         return self.all()
 
-    def _get_cached_categories(self: "CategoryManager") -> models.QuerySet:
+    def _get_cached_categories(self) -> models.QuerySet:
         """Return the cached categories queryset."""
         queryset = cache.get(CATEGORY_CACHE_KEY)
 
@@ -34,7 +34,7 @@ class CategoryManager(models.Manager):
 
         return queryset
 
-    def get_category_by_slug(self: "CategoryManager", slug: str) -> "Category":
+    def get_category_by_slug(self, slug: str) -> "Category":
         """Return a single category by its slug."""
         # First, try to get the category from the cache
         categories = self.get_categories()
@@ -79,11 +79,11 @@ class Category(models.Model):
         verbose_name = "category"
         verbose_name_plural = "categories"
 
-    def __str__(self: "Category") -> str:
+    def __str__(self) -> str:
         """Return the string representation of the category."""
         return self.title
 
-    def save(self: "Category", *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+    def save(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         """Override the save method to auto-generate the slug."""
         if not self.slug:
             self.slug = slugify(self.title)
@@ -118,12 +118,12 @@ class Category(models.Model):
         ).order_by("-date")
 
     @property
-    def has_posts(self: "Category") -> bool:
+    def has_posts(self) -> bool:
         """Return True if the category has published posts."""
         return self.posts.exists()
 
     @property
-    def last_modified(self: "Category") -> None | timezone.datetime:
+    def last_modified(self) -> None | timezone.datetime:
         """Return the most recent last modified date of posts in the category.
 
         This property is used in the sitemap to determine the last modified date of the category.

--- a/src/djpress/models/media.py
+++ b/src/djpress/models/media.py
@@ -69,6 +69,9 @@ class Media(models.Model):
         ("other", "Other"),
     ]
 
+    # Manager
+    objects: MediaManager = MediaManager()
+
     title = models.CharField("Title", max_length=255, help_text="A title for the media file")
     file = models.FileField("File", upload_to=upload_to_path, help_text="The uploaded file")
     media_type = models.CharField(
@@ -95,8 +98,6 @@ class Media(models.Model):
     )
     date = models.DateTimeField(default=timezone.now)
     modified_date = models.DateTimeField(auto_now=True)
-
-    objects: MediaManager = MediaManager()
 
     class Meta:
         """Meta options for the Media model."""

--- a/src/djpress/models/plugin_storage.py
+++ b/src/djpress/models/plugin_storage.py
@@ -45,11 +45,11 @@ class PluginStorageManager(models.Manager):
 class PluginStorage(models.Model):
     """Model for storing plugin data in the database."""
 
+    # Manager
+    objects: PluginStorageManager = PluginStorageManager()
+
     plugin_name = models.CharField(max_length=100, unique=True)
     plugin_data = models.JSONField(default=dict)
-
-    # Manager
-    objects = PluginStorageManager()
 
     class Meta:
         """Meta options for the PluginStorage model."""

--- a/src/djpress/models/tag.py
+++ b/src/djpress/models/tag.py
@@ -91,11 +91,11 @@ class TagManager(models.Manager):
 class Tag(models.Model):
     """Tag model."""
 
+    # Manager
+    objects: TagManager = TagManager()
+
     title = models.CharField(max_length=100, unique=True)
     slug = models.SlugField(max_length=100, unique=True)
-
-    # Custom manager
-    objects: "TagManager" = TagManager()
 
     class Meta:
         """Meta options for the tag model."""
@@ -107,7 +107,7 @@ class Tag(models.Model):
         """Return the title of the tag."""
         return self.title
 
-    def save(self: "Tag", *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+    def save(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
         """Override the save method to auto-generate the slug."""
         if not self.slug:
             self.slug = slugify(self.title)


### PR DESCRIPTION
Remove type hints for `self` in method signatures across various models and add explicit type hints for manager instances. This improves code clarity and consistency.