### PR TITLE
Add minor beta versioning with Bumpver

### DIFF
--- a/justfile
+++ b/justfile
@@ -119,6 +119,11 @@ BUILDDIR      := "docs/_build"
     uv run bumpver update --patch {{ ARGS }}
     uv sync
 
+# Use Bumpver to create a minor beta version. Use just bump-minor-beta -d to view a dry-run.
+@bump-beta *ARGS:
+    uv run bumpver update --patch --tag beta {{ ARGS }}
+    uv sync
+
 # Use BumpVer to increase the minor version number. Use just bump -d to view a dry-run.
 @bump-minor *ARGS:
     uv run bumpver update --minor {{ ARGS }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "djpress"
-version = "0.19.0"
+version = "0.19.1b0"
 description = "A blog application for Django sites, inspired by classic WordPress."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -105,7 +105,7 @@ omit = ["*/tests/*", "*/migrations/*"]
 exclude_lines = ["if TYPE_CHECKING:", "# pragma: no cover"]
 
 [tool.bumpver]
-current_version = "0.19.0"
+current_version = "0.19.1b0"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "👍 bump version {old_version} -> {new_version}"
 commit = true

--- a/src/djpress/__init__.py
+++ b/src/djpress/__init__.py
@@ -1,3 +1,3 @@
 """djpress module."""
 
-__version__ = "0.19.0"
+__version__ = "0.19.1b0"

--- a/uv.lock
+++ b/uv.lock
@@ -331,7 +331,7 @@ wheels = [
 
 [[package]]
 name = "djpress"
-version = "0.19.0"
+version = "0.19.1b0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Introduce a recipe for creating a minor beta version using Bumpver and update the project version to 0.19.1b0.