### PR TITLE
Update version to 0.19.4 and reorder model manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "djpress"
-version = "0.19.3"
+version = "0.19.4"
 description = "A blog application for Django sites, inspired by classic WordPress."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -105,7 +105,7 @@ omit = ["*/tests/*", "*/migrations/*"]
 exclude_lines = ["if TYPE_CHECKING:", "# pragma: no cover"]
 
 [tool.bumpver]
-current_version = "0.19.3"
+current_version = "0.19.4"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "👍 bump version {old_version} -> {new_version}"
 commit = true

--- a/src/djpress/__init__.py
+++ b/src/djpress/__init__.py
@@ -1,3 +1,3 @@
 """djpress module."""
 
-__version__ = "0.19.3"
+__version__ = "0.19.4"

--- a/src/djpress/models/post.py
+++ b/src/djpress/models/post.py
@@ -471,10 +471,10 @@ class Post(models.Model):
     CONTENT_TYPE_CHOICES = [("post", "Post"), ("page", "Page")]
 
     # Managers
-    admin_objects: AdminManager = AdminManager()  # Unfiltered - for admin use only
     objects: PostsAndPagesManager = PostsAndPagesManager()  # Default manager returns only published content
     page_objects: PagesManager = PagesManager()
     post_objects: PostsManager = PostsManager()
+    admin_objects: AdminManager = AdminManager()  # Unfiltered - for admin use only
 
     title = models.CharField(max_length=200, blank=True, help_text="Title is only required for pages.")
     slug = models.SlugField(

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "djpress"
-version = "0.19.3"
+version = "0.19.4"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Bump the version of the project to 0.19.4 and adjust the order of the model manager definitions for clarity.