### PR TITLE
Archives tags

### DIFF
--- a/docs/templatetags.md
+++ b/docs/templatetags.md
@@ -254,6 +254,48 @@ just a single template tag.
 </div>
 ```
 
+### get_archives
+
+Returns date-based archives from the database. This retrieves all years, months, or days that have published posts, along with post counts for each period.
+
+**Note**: specifying `type_` as a keyword argument is optional; it can also be provided as a positional argument.
+All other arguments **must** be provided as keyword arguments.
+
+**Parameters:**
+
+- `type_` (str): The archive frequency type. Accepted values are `"yearly"`, `"monthly"`, and `"daily"`.
+  Default is `"monthly"`, and this can be provided as a positional argument.
+- `limit` (int|None): Limit the number of archive periods returned. Default is `None` (unlimited).
+- `order` (str): Sort order for the periods. Accepted values are `"ASC"` and `"DESC"`. Default is `"DESC"`.
+
+**Returns:** list of dicts. Each dictionary contains:
+- `date` (datetime.date): The date representing the start of the period.
+- `url` (str): The URL of the archive page.
+- `count` (int): The number of posts published in that period.
+- `label` (str): A formatted string representation of the period (e.g., `"2026"`, `"June 2026"`, or `"June 4, 2026"`).
+
+#### get_archives Example
+
+```django
+{% get_archives type_="monthly" as archives %}
+<ul>
+  {% for archive in archives %}
+    <li>
+      <a href="{{ archive.url }}">{{ archive.label }}</a> ({{ archive.count }})
+    </li>
+  {% endfor %}
+</ul>
+```
+
+Note that the following all return the same output, since the `type_` argument can be provided as a positional argument
+and if defaults to `"monthly"`:
+
+```django
+{% get_archives type_="monthly" as archives %}
+{% get_archives "monthly" as archives %}
+{% get_archives as archives %}
+```
+
 ### get_post_title
 
 Returns the title of a post from the current context.
@@ -916,6 +958,81 @@ With CSS classes, and extra parameters:
     <a href="/contact/" class="nav-link">Contact me</a>
   </li>
 </ul>
+```
+
+### site_archives
+
+Get a list of all date-based archives formatted in HTML.
+
+**Returns:** date-based archives as HTML which has been marked as safe.
+
+#### site_archives Parameters
+
+- `type_` (str): The archive frequency type. Accepted values are `"yearly"`, `"monthly"`, and `"daily"`. Default is `"monthly"`.
+- `outer_tag` (str): the outer tag that this should be wrapped in. Accepted options are `"ul"`, `"ol"`, `"div"`, `"span"`. If `"ul"` or `"ol"` is used, then the inner items will be wrapped with `"li"` tags. Default is: `"ul"`.
+- `limit` (int|None): Limit the number of archive periods returned. Default is `None` (unlimited).
+- `order` (str): Sort order for the periods. Accepted values are `"ASC"` and `"DESC"`. Default is `"DESC"`.
+- `show_post_count` (bool): Whether to display the post counts in parentheses next to the links. Default is `False`.
+- `outer_class` (str): the CSS classes to apply to the outer tag. Default: `""`.
+- `li_class` (str): the CSS classes to apply to the list item tags (only relevant if outer tag is `"ul"` or `"ol"`). Default: `""`.
+- `link_class` (str): the CSS classes to apply to the link tags. Default: `""`.
+- `separator` (str): the separator to use between archives. Only relevant when not using `"ul"` or `"ol"` as the outer tag. Default: `", "`.
+- `pre_text` (str): the text to prepend to the list of archives. Default: `""`.
+- `post_text` (str): the text to append to the list of archives. Default: `""`.
+
+**Note**: specifying `type_` as a keyword argument is optional; it can also be provided as a positional argument.
+All other arguments **must** be provided as keyword arguments.
+
+#### site_archives Examples
+
+Just the archives, with no arguments (defaults to monthly):
+
+```django
+{% site_archives %}
+```
+
+Outputs:
+
+```html
+<ul>
+  <li>
+    <a href="/2026/06/" title="View all posts from June 2026">June 2026</a>
+  </li>
+  <li>
+    <a href="/2026/05/" title="View all posts from May 2026">May 2026</a>
+  </li>
+</ul>
+```
+
+Show monthly archives with post counts wrapped in an ordered list with custom CSS classes:
+
+```django
+{% site_archives outer_tag="ol" show_post_count=True outer_class="archive-list" li_class="archive-item" link_class="archive-link" %}
+```
+
+Outputs:
+
+```html
+<ol class="archive-list">
+  <li class="archive-item">
+    <a href="/2026/06/" title="View all posts from June 2026" class="archive-link">June 2026</a> (3)
+  </li>
+  <li class="archive-item">
+    <a href="/2026/05/" title="View all posts from May 2026" class="archive-link">May 2026</a> (1)
+  </li>
+</ol>
+```
+
+Wrapped in a `span` tag with a custom separator:
+
+```django
+{% site_archives "yearly" outer_tag="span" separator=" | " pre_text="Archives: " post_text="." %}
+```
+
+Outputs:
+
+```html
+<span>Archives: <a href="/2026/" title="View all posts from 2026">2026</a> | <a href="/2025/" title="View all posts from 2025">2025</a>.</span>
 ```
 
 ## Post Content Tags

--- a/src/djpress/models/post.py
+++ b/src/djpress/models/post.py
@@ -9,7 +9,8 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Case, IntegerField, Max, Q, Value, When
+from django.db.models import Case, Count, IntegerField, Max, Q, Value, When
+from django.db.models.functions import TruncDay, TruncMonth, TruncYear
 from django.db.transaction import on_commit
 from django.utils import timezone
 from django.utils.text import slugify
@@ -547,6 +548,39 @@ class PostsManager(models.Manager):
         return self.filter(_date__year=year, _date__month=month, _date__day=day).aggregate(
             latest=Max("updated_at"),
         )["latest"]
+
+    def get_archive_periods(self, period_type: str = "monthly", order: str = "DESC") -> list[dict]:
+        """Return distinct archive periods with published post counts.
+
+        The Django `Trunc` functions normalise dates to the start of that specific period.
+
+        Args:
+            period_type: "yearly", "monthly", or "daily".
+            order: "ASC" or "DESC".
+
+        Returns:
+            list[dict]: A list of dicts, each with keys:
+                - 'period': datetime.date representing the start of the period
+                - 'count': int, number of posts in that period
+        """
+        if period_type == "yearly":
+            trunc_func = TruncYear("_date")
+        elif period_type == "daily":
+            trunc_func = TruncDay("_date")
+        else:
+            trunc_func = TruncMonth("_date")
+
+        # Reverse the order with a minus sign.
+        order_prefix = "" if order.upper() == "ASC" else "-"
+
+        return list(
+            self.get_published_posts()
+            .filter(_date__isnull=False)
+            .annotate(period=trunc_func)  # add the period field with the trunc function
+            .values("period")  # group by period
+            .annotate(count=Count("id"))  # count the posts in each group
+            .order_by(f"{order_prefix}period")  # order_prefix will either be blank or a minus sign
+        )
 
 
 class Post(models.Model):

--- a/src/djpress/templates/djpress/simple/index.html
+++ b/src/djpress/templates/djpress/simple/index.html
@@ -38,6 +38,7 @@
       {% site_categories %}
       <h3>Tags:</h3>
       {% tags_with_counts %}
+      {% site_archives show_post_count=True pre_text="<h3>Archives:</h3>" %}
     </nav>
     <main>
       {% if post %}

--- a/src/djpress/templatetags/djpress_tags.py
+++ b/src/djpress/templatetags/djpress_tags.py
@@ -303,6 +303,76 @@ def get_pagination_current_page(context: Context) -> int:
     return page.number
 
 
+@register.simple_tag
+def get_archives(
+    type_: str = "monthly",
+    *,
+    limit: int | None = None,
+    order: str = "DESC",
+) -> list[dict]:
+    """Return date-based archives.
+
+    The type of archives can be provided as an argument. All other parameters must be passed as keyword arguments.
+    The type (`type_`) must be one of: "yearly", "monthly", "daily".
+
+    The limit must be an integer, or `None` to mean no limit. If omitted, the default is no limit (`None`).
+
+    The order must be one of: "ASC", "DESC". If ommitted, the default is descending (`DESC`).
+
+    Args:
+        type_: "yearly", "monthly", or "daily".
+        limit: Maximum number of archive periods to return.
+        order: Sort order, "ASC" or "DESC".
+
+    Returns:
+        list[dict]: A list of dictionaries containing:
+            - 'date': datetime.date object representing the archive period
+            - 'url': The URL of the archive page
+            - 'count': Number of posts in this archive period
+            - 'label': A formatted string representation (e.g. "June 2026")
+    """
+    if (
+        not djpress_settings.ARCHIVE_ENABLED
+        or type_ not in {"yearly", "monthly", "daily"}
+        or order not in {"ASC", "DESC"}
+    ):
+        return []
+
+    periods = Post.post_objects.get_archive_periods(period_type=type_, order=order)
+    if limit is not None:
+        periods = periods[:limit]
+
+    results = []
+    for item in periods:
+        period_date = item["period"]
+        count = item["count"]
+
+        if type_ == "yearly":
+            url = url_utils.get_archives_url(year=period_date.year)
+            label = period_date.strftime("%Y")
+        elif type_ == "daily":
+            url = url_utils.get_archives_url(
+                year=period_date.year,
+                month=period_date.month,
+                day=period_date.day,
+            )
+            label = f"{period_date.strftime('%B')} {period_date.day}, {period_date.strftime('%Y')}"
+        else:  # monthly
+            url = url_utils.get_archives_url(year=period_date.year, month=period_date.month)
+            label = period_date.strftime("%B %Y")
+
+        results.append(
+            {
+                "date": period_date,
+                "url": url,
+                "count": count,
+                "label": label,
+            }
+        )
+
+    return results
+
+
 """
 # Display Tags - Site-wide
 
@@ -654,6 +724,76 @@ def site_pages_list(
     content = format_html("{}{}", home_li, inner_list)
 
     return helpers.wrap_in_tag(content, "ul", ul_outer_class)
+
+
+@register.simple_tag
+def site_archives(
+    type_: str = "monthly",
+    *,
+    outer_tag: str = "ul",
+    limit: int | None = None,
+    order: str = "DESC",
+    show_post_count: bool = False,
+    outer_class: str = "",
+    li_class: str = "",
+    link_class: str = "",
+    separator: str = ", ",
+    pre_text: str = "",
+    post_text: str = "",
+) -> str:
+    """Return the archives of the blog as HTML.
+
+    The type of archives can be provided as an argument. All other parameters must be passed as keyword arguments.
+    The type (`type_`) must be one of: "yearly", "monthly", "daily", and defaults to "monthly" if not provided.
+
+    The outer tag must be one of: "ul", "ol", "div", "span".
+
+    The limit must be an integer, or `None` to mean no limit. If omitted, the default is no limit (`None`).
+
+    The order must be one of: "ASC", "DESC". If ommitted, the default is descending (`DESC`).
+
+    Args:
+        type_: "yearly", "monthly", or "daily".
+        outer_tag: The outer HTML tag for the archives ("ul", "ol", "div", "span").
+        limit: Maximum number of archive periods to display.
+        order: Sort order, "ASC" or "DESC".
+        show_post_count: Whether to display post counts.
+        outer_class: CSS class(es) for the outer tag.
+        li_class: CSS class(es) for the list items (only if outer_tag is "ul" or "ol").
+        link_class: CSS class(es) for the anchor tags.
+        separator: Separator between items (only if outer_tag is "div" or "span").
+        pre_text: Text/HTML to prepend to the list.
+        post_text: Text/HTML to append to the list.
+
+    Returns:
+        str: The archives list as safely marked HTML.
+    """
+    if (
+        not djpress_settings.ARCHIVE_ENABLED
+        or type_ not in {"yearly", "monthly", "daily"}
+        or outer_tag not in {"ul", "ol", "div", "span"}
+        or order not in {"ASC", "DESC"}
+    ):
+        return ""
+
+    archives = get_archives(type_=type_, limit=limit, order=order)
+    if not archives:
+        return ""
+
+    return format_html(
+        "{}",
+        helpers.archives_html(
+            archives=archives,
+            outer_tag=outer_tag,
+            outer_class=outer_class,
+            link_class=link_class,
+            li_class=li_class,
+            separator=separator,
+            show_post_count=show_post_count,
+            pre_text=pre_text,
+            post_text=post_text,
+        ),
+    )
 
 
 """

--- a/src/djpress/templatetags/helpers.py
+++ b/src/djpress/templatetags/helpers.py
@@ -27,7 +27,7 @@ def wrap_in_tag(content: str | SafeString, tag: str, css_class: str = "") -> str
     if not tag:
         return format_html("{}", content)
 
-    allowed_tags = {"h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "span", "section", "article", "li", "ul"}
+    allowed_tags = {"h1", "h2", "h3", "h4", "h5", "h6", "p", "div", "span", "section", "article", "li", "ul", "ol"}
     if tag not in allowed_tags:
         return ""
 
@@ -72,6 +72,75 @@ def build_html_link(
         class_html,
         text,
     )
+
+
+def archives_html(
+    archives: list[dict],
+    *,
+    outer_tag: str = "ul",
+    outer_class: str = "",
+    link_class: str = "",
+    li_class: str = "",
+    separator: str = ", ",
+    show_post_count: bool = False,
+    pre_text: str = "",
+    post_text: str = "",
+) -> str | SafeString:
+    """Return the HTML representation of a list of archives.
+
+    Args:
+        archives: List of archive dictionaries.
+        outer_tag: Outer tag (ul, ol, div, span).
+        outer_class: CSS class for the outer tag.
+        link_class: CSS class for anchor tags.
+        li_class: CSS class for list item tags (if outer_tag is ul or ol).
+        separator: Separator used between links (if outer_tag is div or span).
+        show_post_count: Whether to display post count next to links.
+        pre_text: Text/HTML to prepend.
+        post_text: Text/HTML to append.
+
+    Returns:
+        str | SafeString: Safe HTML representation.
+    """
+    if not archives:
+        return ""
+
+    # The helper tag is more forgiving. The user-facing tags should enforce stricter tag selection.
+    if outer_tag not in {"ul", "ol", "div", "span"}:
+        outer_tag = "ul"
+
+    items = []
+    for archive in archives:
+        url = archive["url"]
+        label = archive["label"]
+        count = archive["count"]
+        title = f"View all posts from {label}"
+
+        link_html = build_html_link(
+            url=url,
+            text=label,
+            title=title,
+            css_class=link_class,
+        )
+
+        item_content = format_html("{} ({})", link_html, count) if show_post_count else link_html
+
+        if outer_tag in {"ul", "ol"}:
+            li_class_html = format_html(' class="{}"', li_class) if li_class else ""
+            item_html = format_html("<li{}>{}</li>", li_class_html, item_content)
+        else:
+            item_html = item_content
+
+        items.append(item_html)
+
+    if outer_tag in {"ul", "ol"}:
+        joined_items = mark_safe("".join(items))
+    else:
+        escaped_separator = conditional_escape(separator)
+        joined_items = mark_safe(escaped_separator.join(items))
+
+    wrapped = wrap_in_tag(joined_items, outer_tag, outer_class)
+    return format_html("{}{}{}", pre_text, wrapped, post_text)
 
 
 def categories_html(

--- a/tests/test_models_post.py
+++ b/tests/test_models_post.py
@@ -1631,3 +1631,136 @@ def test_post_search_plugin_returns_queryset(test_post1, test_post2):
         assert posts.count() == 1
         assert test_post1 in posts
         assert test_post2 not in posts
+
+
+@pytest.mark.django_db
+def test_get_archive_periods(user):
+    # Setup posts:
+    # 1. Active posts:
+    #   - Post A: 2024-06-04
+    #   - Post B: 2024-06-05
+    #   - Post C: 2024-05-15
+    #   - Post D: 2023-01-01
+    # 2. Excluded posts:
+    #   - Post E: Draft post
+    #   - Post F: Future post
+    #   - Page G: Page type post
+
+    now = timezone.now()
+
+    # 2024-06-04 post
+    Post.post_objects.create(
+        title="Post A",
+        slug="post-a",
+        content="A",
+        author=user,
+        status="published",
+        post_type="post",
+        published_at=datetime.datetime(2024, 6, 4, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+    # 2024-06-05 post (same month/year as A, but different day)
+    Post.post_objects.create(
+        title="Post B",
+        slug="post-b",
+        content="B",
+        author=user,
+        status="published",
+        post_type="post",
+        published_at=datetime.datetime(2024, 6, 5, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+    # 2024-05-15 post (same year, different month)
+    Post.post_objects.create(
+        title="Post C",
+        slug="post-c",
+        content="C",
+        author=user,
+        status="published",
+        post_type="post",
+        published_at=datetime.datetime(2024, 5, 15, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+    # 2023-01-01 post (different year)
+    Post.post_objects.create(
+        title="Post D",
+        slug="post-d",
+        content="D",
+        author=user,
+        status="published",
+        post_type="post",
+        published_at=datetime.datetime(2023, 1, 1, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+
+    # Draft post
+    Post.post_objects.create(
+        title="Post E (Draft)",
+        slug="post-e",
+        content="E",
+        author=user,
+        status="draft",
+        post_type="post",
+        published_at=datetime.datetime(2024, 6, 4, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+    # Future post
+    Post.post_objects.create(
+        title="Post F (Future)",
+        slug="post-f",
+        content="F",
+        author=user,
+        status="published",
+        post_type="post",
+        published_at=now + datetime.timedelta(days=10),
+    )
+    # Page
+    Post.post_objects.create(
+        title="Page G",
+        slug="page-g",
+        content="G",
+        author=user,
+        status="published",
+        post_type="page",
+        published_at=datetime.datetime(2024, 6, 4, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+
+    # Test monthly (default) - DESC (default)
+    monthly_desc = Post.post_objects.get_archive_periods(period_type="monthly", order="DESC")
+    # Expected:
+    # 1. 2024-06-01 (count=2: Post A and B)
+    # 2. 2024-05-01 (count=1: Post C)
+    # 3. 2023-01-01 (count=1: Post D)
+    assert len(monthly_desc) == 3
+    assert monthly_desc[0]["period"] == datetime.date(2024, 6, 1)
+    assert monthly_desc[0]["count"] == 2
+    assert monthly_desc[1]["period"] == datetime.date(2024, 5, 1)
+    assert monthly_desc[1]["count"] == 1
+    assert monthly_desc[2]["period"] == datetime.date(2023, 1, 1)
+    assert monthly_desc[2]["count"] == 1
+
+    # Test monthly - ASC
+    monthly_asc = Post.post_objects.get_archive_periods(period_type="monthly", order="ASC")
+    assert len(monthly_asc) == 3
+    assert monthly_asc[0]["period"] == datetime.date(2023, 1, 1)
+    assert monthly_asc[1]["period"] == datetime.date(2024, 5, 1)
+    assert monthly_asc[2]["period"] == datetime.date(2024, 6, 1)
+
+    # Test yearly - DESC
+    yearly_desc = Post.post_objects.get_archive_periods(period_type="yearly", order="DESC")
+    # Expected:
+    # 1. 2024-01-01 (count=3: A, B, C)
+    # 2. 2023-01-01 (count=1: D)
+    assert len(yearly_desc) == 2
+    assert yearly_desc[0]["period"] == datetime.date(2024, 1, 1)
+    assert yearly_desc[0]["count"] == 3
+    assert yearly_desc[1]["period"] == datetime.date(2023, 1, 1)
+    assert yearly_desc[1]["count"] == 1
+
+    # Test daily - DESC
+    daily_desc = Post.post_objects.get_archive_periods(period_type="daily", order="DESC")
+    # Expected:
+    # 1. 2024-06-05 (count=1: B)
+    # 2. 2024-06-04 (count=1: A)
+    # 3. 2024-05-15 (count=1: C)
+    # 4. 2023-01-01 (count=1: D)
+    assert len(daily_desc) == 4
+    assert daily_desc[0]["period"] == datetime.date(2024, 6, 5)
+    assert daily_desc[1]["period"] == datetime.date(2024, 6, 4)
+    assert daily_desc[2]["period"] == datetime.date(2024, 5, 15)
+    assert daily_desc[3]["period"] == datetime.date(2023, 1, 1)

--- a/tests/test_templatetags_djpress_tags.py
+++ b/tests/test_templatetags_djpress_tags.py
@@ -1,6 +1,7 @@
 from djpress.conf import settings as djpress_settings
 from django.utils import timezone
 import pytest
+import datetime
 from django.contrib.auth.models import User
 from django.core.paginator import Paginator
 from django.template import Context, Template
@@ -2713,3 +2714,148 @@ def test_get_theme_setting(settings):
 
     # Test with a theme setting
     assert djpress_tags.get_theme_setting("test_setting") == "test_value"
+
+
+@pytest.mark.django_db
+def test_get_archives(user, settings):
+    # Enable archives
+    settings.DJPRESS_SETTINGS["ARCHIVE_ENABLED"] = True
+
+    # Setup posts:
+    # 2024-06-04 post
+    Post.post_objects.create(
+        title="Post A",
+        slug="post-a",
+        content="A",
+        author=user,
+        status="published",
+        post_type="post",
+        published_at=datetime.datetime(2024, 6, 4, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+    # 2024-06-05 post (same month/year as A, but different day)
+    Post.post_objects.create(
+        title="Post B",
+        slug="post-b",
+        content="B",
+        author=user,
+        status="published",
+        post_type="post",
+        published_at=datetime.datetime(2024, 6, 5, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+    # 2024-05-15 post (same year, different month)
+    Post.post_objects.create(
+        title="Post C",
+        slug="post-c",
+        content="C",
+        author=user,
+        status="published",
+        post_type="post",
+        published_at=datetime.datetime(2024, 5, 15, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+    # 2023-01-01 post (different year)
+    Post.post_objects.create(
+        title="Post D",
+        slug="post-d",
+        content="D",
+        author=user,
+        status="published",
+        post_type="post",
+        published_at=datetime.datetime(2023, 1, 1, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+
+    # Test monthly
+    res_monthly = djpress_tags.get_archives(type_="monthly")
+    assert len(res_monthly) == 3
+    assert res_monthly[0]["label"] == "June 2024"
+    assert res_monthly[0]["count"] == 2
+    assert res_monthly[0]["url"] == f"/{settings.DJPRESS_SETTINGS['ARCHIVE_PREFIX']}/2024/06/"
+    assert res_monthly[1]["label"] == "May 2024"
+    assert res_monthly[1]["count"] == 1
+    assert res_monthly[2]["label"] == "January 2023"
+    assert res_monthly[2]["count"] == 1
+
+    # Test monthly limited
+    res_monthly_lim = djpress_tags.get_archives(type_="monthly", limit=2)
+    assert len(res_monthly_lim) == 2
+    assert res_monthly_lim[0]["label"] == "June 2024"
+    assert res_monthly_lim[1]["label"] == "May 2024"
+
+    # Test yearly
+    res_yearly = djpress_tags.get_archives(type_="yearly")
+    assert len(res_yearly) == 2
+    assert res_yearly[0]["label"] == "2024"
+    assert res_yearly[0]["count"] == 3
+    assert res_yearly[0]["url"] == f"/{settings.DJPRESS_SETTINGS['ARCHIVE_PREFIX']}/2024/"
+    assert res_yearly[1]["label"] == "2023"
+    assert res_yearly[1]["count"] == 1
+
+    # Test daily
+    res_daily = djpress_tags.get_archives(type_="daily")
+    assert len(res_daily) == 4
+    assert res_daily[0]["label"] == "June 5, 2024"
+    assert res_daily[0]["count"] == 1
+    assert res_daily[0]["url"] == f"/{settings.DJPRESS_SETTINGS['ARCHIVE_PREFIX']}/2024/06/05/"
+    assert res_daily[1]["label"] == "June 4, 2024"
+    assert res_daily[1]["count"] == 1
+    assert res_daily[2]["label"] == "May 15, 2024"
+    assert res_daily[3]["label"] == "January 1, 2023"
+
+    # Test invalid type (defaults to empty list)
+    res_invalid = djpress_tags.get_archives(type_="invalid")
+    assert len(res_invalid) == 0
+
+
+@pytest.mark.django_db
+def test_site_archives(user, settings):
+    # Enable archives
+    settings.DJPRESS_SETTINGS["ARCHIVE_ENABLED"] = True
+
+    # Setup post
+    Post.post_objects.create(
+        title="Post A",
+        slug="post-a",
+        content="A",
+        author=user,
+        status="published",
+        post_type="post",
+        published_at=datetime.datetime(2024, 6, 4, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+
+    prefix = settings.DJPRESS_SETTINGS["ARCHIVE_PREFIX"]
+    expected_html = (
+        f'<ul><li><a href="/{prefix}/2024/06/" title="View all posts from June 2024">June 2024</a></li></ul>'
+    )
+    assert djpress_tags.site_archives() == expected_html
+
+    expected_html_with_count = (
+        f'<ul><li><a href="/{prefix}/2024/06/" title="View all posts from June 2024">June 2024</a> (1)</li></ul>'
+    )
+    assert djpress_tags.site_archives(show_post_count=True) == expected_html_with_count
+
+    # Test site_archives when get_archives returns empty
+    settings.DJPRESS_SETTINGS["ARCHIVE_ENABLED"] = False
+    assert djpress_tags.site_archives() == ""
+
+    settings.DJPRESS_SETTINGS["ARCHIVE_ENABLED"] = True
+    # Delete posts to simulate no archives found
+    Post.objects.all().delete()
+    assert djpress_tags.site_archives() == ""
+
+
+@pytest.mark.django_db
+def test_archives_disabled(user, settings):
+    settings.DJPRESS_SETTINGS["ARCHIVE_ENABLED"] = False
+
+    # Setup post
+    Post.post_objects.create(
+        title="Post A",
+        slug="post-a",
+        content="A",
+        author=user,
+        status="published",
+        post_type="post",
+        published_at=datetime.datetime(2024, 6, 4, 12, 0, tzinfo=timezone.get_current_timezone()),
+    )
+
+    assert djpress_tags.get_archives() == []
+    assert djpress_tags.site_archives() == ""

--- a/tests/test_templatetags_helpers.py
+++ b/tests/test_templatetags_helpers.py
@@ -12,6 +12,7 @@ from djpress.templatetags.helpers import (
     tags_html,
     get_page_link,
     wrap_in_tag,
+    archives_html,
 )
 
 
@@ -515,8 +516,89 @@ def test_wrap_in_tag():
     result = wrap_in_tag(content="This is the content", tag="div")
     assert result == "<div>This is the content</div>"
 
+    result = wrap_in_tag(content="This is the content", tag="ol", css_class="archive-list")
+    assert result == '<ol class="archive-list">This is the content</ol>'
+
     result = wrap_in_tag(content="This is the content", tag="", css_class="blog-post")
     assert result == "This is the content"
 
     result = wrap_in_tag(content="This is the content", tag="foobar", css_class="blog-post")
     assert result == ""
+
+
+def test_archives_html():
+    archives = [
+        {"url": "/2026/06/", "label": "June 2026", "count": 3},
+        {"url": "/2026/05/", "label": "May 2026", "count": 1},
+    ]
+
+    # Test case 1: default options (ul, no counts, no classes)
+    expected_output = (
+        "<ul>"
+        '<li><a href="/2026/06/" title="View all posts from June 2026">June 2026</a></li>'
+        '<li><a href="/2026/05/" title="View all posts from May 2026">May 2026</a></li>'
+        "</ul>"
+    )
+    assert archives_html(archives) == expected_output
+
+    # Test case 2: showing post counts in list
+    expected_output_counts = (
+        "<ul>"
+        '<li><a href="/2026/06/" title="View all posts from June 2026">June 2026</a> (3)</li>'
+        '<li><a href="/2026/05/" title="View all posts from May 2026">May 2026</a> (1)</li>'
+        "</ul>"
+    )
+    assert archives_html(archives, show_post_count=True) == expected_output_counts
+
+    # Test case 3: ol tag with classes
+    expected_output_ol = (
+        '<ol class="outer-c">'
+        '<li class="li-c"><a href="/2026/06/" title="View all posts from June 2026" class="link-c">June 2026</a></li>'
+        '<li class="li-c"><a href="/2026/05/" title="View all posts from May 2026" class="link-c">May 2026</a></li>'
+        "</ol>"
+    )
+    assert (
+        archives_html(
+            archives,
+            outer_tag="ol",
+            outer_class="outer-c",
+            li_class="li-c",
+            link_class="link-c",
+        )
+        == expected_output_ol
+    )
+
+    # Test case 4: div with custom separator, pre_text, post_text
+    expected_output_div = (
+        "Pre-text"
+        '<div class="outer-c">'
+        '<a href="/2026/06/" title="View all posts from June 2026" class="link-c">June 2026</a> (3) | '
+        '<a href="/2026/05/" title="View all posts from May 2026" class="link-c">May 2026</a> (1)'
+        "</div>"
+        "Post-text"
+    )
+    assert (
+        archives_html(
+            archives,
+            outer_tag="div",
+            outer_class="outer-c",
+            link_class="link-c",
+            separator=" | ",
+            show_post_count=True,
+            pre_text="Pre-text",
+            post_text="Post-text",
+        )
+        == expected_output_div
+    )
+
+    # Test case 5: empty list
+    assert archives_html([]) == ""
+
+    # Test case 6: invalid tag defaults to ul
+    expected_invalid = (
+        "<ul>"
+        '<li><a href="/2026/06/" title="View all posts from June 2026">June 2026</a></li>'
+        '<li><a href="/2026/05/" title="View all posts from May 2026">May 2026</a></li>'
+        "</ul>"
+    )
+    assert archives_html(archives, outer_tag="invalid") == expected_invalid


### PR DESCRIPTION
New archives templates tags, loosely inspired by WordPress's `wp_get_archives`.

- `get_archives` returns a list of dicts for manual looping in a template
- `site_archives` returns safe HTML that displays a list of tags.

Included tests and docs.