### PR TITLE
More templatetag tests

### DIFF
--- a/docs/templatetags.md
+++ b/docs/templatetags.md
@@ -725,27 +725,23 @@ Get a list of all tags wrapped in HTML that can be configured with optional argu
 
 **Returns:** all tags as HTML which has been marked as safe.
 
-> **Related Topics:** See [tags.md](tags.md) for more information about tags and [url_structure.md](url_structure.md)
-for tag URL patterns.
+> **Related Topics:** See [tags.md](tags.md) for more information about tags and [url_structure.md](url_structure.md) for tag URL patterns.
 
 #### site_tags Parameters
 
-- `outer_tag` (str): the outer tag that this should be wrapped in. Accepted options are "ul", "div", "span". If "ul" is used, then the inner items will be wrapped with "li" tags.
-Default is: "ul".
+- `outer_tag` (str): the outer tag that this should be wrapped in. Accepted options are "ul", "ol", "div", "span". If "ul" or "ol" is used, then the inner items will be wrapped with "li" tags. Default is: "ul".
 - `outer_class` (str): the CSS classes to apply to the outer tag. Default: "".
 - `link_class` (str): the CSS classes to apply to the link tag. Default: "".
-- `separator` (str): the separator to use between categories. Only relevant when not using "ul" as the outer tag.
-Default: ", ".
-- `pre_text` (str): the text to prepend to the list of categories. Only relevant when not using "ul" as the outer tag.
-Default: "".
-- `post_text` (str): the text to append to the list of categories. Only relevant when not using "ul" as the outer tag.
-Default: "".
+- `separator` (str): the separator to use between tags. Only relevant when not using "ul" or "ol" as the outer tag. Default: ", ".
+- `pre_text` (str): the text to prepend to the list of tags. Default: "".
+- `post_text` (str): the text to append to the list of tags. Default: "".
+- `show_post_count` (bool): whether to display the post counts in parentheses next to the links. Default: False.
 
 **Note:** `outer_tag` can be passed as a positional argument, but the other parameters must be passed as keyword arguments.
 
 #### site_tags Examples
 
-Just the tags, with no arguments.
+Just the tags, with no arguments:
 
 ```django
 {% site_tags %}
@@ -762,6 +758,25 @@ Outputs a list of all tags:
     <a href="/tag/django/" title="View all posts tagged with Django">Django</a>
   </li>
 </ul>
+```
+
+Show tags with post counts, wrapping them in an ordered list with custom CSS classes:
+
+```django
+{% site_tags "ol" show_post_count=True outer_class="tag-list" link_class="tag-link" %}
+```
+
+Outputs:
+
+```html
+<ol class="tag-list">
+  <li>
+    <a href="/tag/python/" title="View all posts tagged with Python" class="tag-link">Python</a> (5)
+  </li>
+  <li>
+    <a href="/tag/django/" title="View all posts tagged with Django" class="tag-link">Django</a> (3)
+  </li>
+</ol>
 ```
 
 Wrapped in a `div` tag:
@@ -790,55 +805,6 @@ Wrapped in a `span` tag with all optional parameters:
 </span>
 ```
 
-### tags_with_counts
-
-Get a list of all tags with post counts wrapped in HTML that can be configured with optional arguments.
-
-**Returns:** all tags with post counts as HTML which has been marked as safe.
-
-#### tags_with_counts Parameters
-
-- `outer_tag` (str): the outer tags that this should be wrapped in.  Optional, default is: "ul".
-- `outer_class` (str): the CSS classes to apply to the outer tag. Optional, default: "".
-- `link_class` (str): the CSS classes to apply to the link tag. Optional, default: "".
-
-**Note:** `outer_tag` can be passed as a positional argument, but the other parameters must be passed as keyword arguments.
-
-#### tags_with_counts Examples
-
-Just the tag, with no arguments.
-
-```django
-{% tags_with_counts %}
-```
-
-Outputs a list of all tags with post counts:
-
-```html
-<ul>
-  <li>
-    <a href="/tag/python/" title="View all posts tagged with Python">Python</a> (5)
-  </li>
-  <li>
-    <a href="/tag/django/" title="View all posts tagged with Django">Django</a> (3)
-  </li>
-</ul>
-```
-
-Wrapped in a `div` tag with classes added.
-
-```django
-{% tags_with_counts outer_tag="div" outer_class="tag-cloud" link_class="tag" %}
-```
-
-Outputs a comma-separated list of tags with post counts, wrapped in a `div` tag.
-
-```html
-<div class="tag-cloud">
-  <a href="/tag/python/" title="View all posts tagged with Python" class="tag">Python</a> (5),
-  <a href="/tag/django/" title="View all posts tagged with Django" class="tag">Django</a> (3)
-</div>
-```
 
 ### site_pages
 

--- a/src/djpress/models/tag.py
+++ b/src/djpress/models/tag.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from django.core.cache import cache
 from django.db import IntegrityError, models, transaction
-from django.db.models import Max
+from django.db.models import Count, Max, Q
 from django.utils import timezone
 from django.utils.text import slugify
 
@@ -82,12 +82,25 @@ class TagManager(models.Manager):
 
         return tag
 
-    def get_tags_with_published_posts(self) -> models.QuerySet:
-        """Return a queryset of tags that have published posts.
+    def get_tags_with_counts(self, *, published_only: bool = True) -> models.QuerySet:
+        """Return a queryset of tags annotated with the count of their published posts.
 
-        We can use the has_posts property to include only tags with published posts.
+        Args:
+            published_only: If True (default), filter out tags with no published posts.
         """
-        return Tag.objects.filter(pk__in=[tag.pk for tag in self.get_queryset() if tag.has_posts])
+        qs = self.get_queryset().annotate(
+            num_posts=Count(
+                "_posts",
+                filter=Q(
+                    _posts__post_type="post",
+                    _posts__status="published",
+                    _posts__published_at__lte=timezone.now(),
+                ),
+            )
+        )
+        if published_only:
+            qs = qs.filter(num_posts__gt=0)
+        return qs
 
 
 class Tag(models.Model):

--- a/src/djpress/templates/djpress/simple/index.html
+++ b/src/djpress/templates/djpress/simple/index.html
@@ -34,8 +34,7 @@
           </li>
         {% endfor %}
       </ul>
-      <h3>Categories:</h3>
-      {% site_categories %}
+      {% site_categories pre_text="<h3>Categories:</h3>" %}
       <h3>Tags:</h3>
       {% tags_with_counts %}
       {% site_archives show_post_count=True pre_text="<h3>Archives:</h3>" %}

--- a/src/djpress/templates/djpress/simple/index.html
+++ b/src/djpress/templates/djpress/simple/index.html
@@ -35,8 +35,7 @@
         {% endfor %}
       </ul>
       {% site_categories pre_text="<h3>Categories:</h3>" %}
-      <h3>Tags:</h3>
-      {% tags_with_counts %}
+      {% site_tags show_post_count=True pre_text="<h3>Tags:</h3>" %}
       {% site_archives show_post_count=True pre_text="<h3>Archives:</h3>" %}
     </nav>
     <main>

--- a/src/djpress/templatetags/djpress_tags.py
+++ b/src/djpress/templatetags/djpress_tags.py
@@ -541,6 +541,7 @@ def site_tags(
     separator: str = ", ",
     pre_text: str = "",
     post_text: str = "",
+    show_post_count: bool = False,
 ) -> str:
     """Return the tags of the blog.
 
@@ -551,11 +552,16 @@ def site_tags(
         separator: The separator between tags.
         pre_text: The text to prepend to the tags.
         post_text: The text to append to the tags.
+        show_post_count: Whether to display post counts.
 
     Returns:
         str: The tags of the blog.
     """
-    tags = Tag.objects.get_tags().order_by("title")
+    if show_post_count:
+        tags = Tag.objects.get_tags_with_counts(published_only=True).order_by("title")
+    else:
+        tags = Tag.objects.get_tags().order_by("title")
+
     if not tags:
         return ""
 
@@ -569,50 +575,9 @@ def site_tags(
             separator=separator,
             pre_text=pre_text,
             post_text=post_text,
+            show_post_count=show_post_count,
         ),
     )
-
-
-@register.simple_tag
-def tags_with_counts(
-    outer_tag: str = "ul",
-    *,
-    outer_class: str = "",
-    link_class: str = "",
-) -> str:
-    """Return the tags of the blog with post counts.
-
-    Each tag shows the tag name followed by the number of posts in parentheses.
-    Only tags that have published posts are included.
-
-    Args:
-        outer_tag: The outer HTML tag for the tags: "ul", "div", or "span".
-        outer_class: The CSS class(es) for the outer tag.
-        link_class: The CSS class(es) for the link.
-
-    Returns:
-        str: The tags of the blog with post counts.
-    """
-    tags = Tag.objects.get_tags_with_published_posts().order_by("title")
-
-    if not tags:
-        return ""
-
-    if outer_tag not in ["ul", "div", "span"]:
-        return ""
-
-    if outer_tag == "ul":
-        items_html = format_html_join(
-            "",
-            "<li>{} ({})</li>",
-            ((helpers.get_tag_link(tag, link_class), tag.posts.count()) for tag in tags),
-        )
-        return helpers.wrap_in_tag(items_html, "ul", outer_class)
-
-    # For div or span, we join with a comma and space
-    items = [format_html("{} ({})", helpers.get_tag_link(tag, link_class), tag.posts.count()) for tag in tags]
-    joined_items = mark_safe(", ".join(items))
-    return helpers.wrap_in_tag(joined_items, outer_tag, outer_class)
 
 
 @register.simple_tag

--- a/src/djpress/templatetags/helpers.py
+++ b/src/djpress/templatetags/helpers.py
@@ -234,7 +234,8 @@ def tags_html(
                 "<li>{}</li>",
                 ((get_tag_link(tag, link_class),) for tag in tags),
             )
-        return wrap_in_tag(items_html, outer_tag, outer_class)
+        wrapped = wrap_in_tag(items_html, outer_tag, outer_class)
+        return format_html("{}{}{}", pre_text, wrapped, post_text)
 
     if show_post_count:
         items = [format_html("{} ({})", get_tag_link(tag, link_class), getattr(tag, "num_posts", 0)) for tag in tags]

--- a/src/djpress/templatetags/helpers.py
+++ b/src/djpress/templatetags/helpers.py
@@ -156,6 +156,8 @@ def categories_html(
 
     Note this isn't a template tag, but a helper function for the other template tags
 
+    Note that separator has no effect when used with a list (i.e. `ol`, `ul`)
+
     Args:
         categories (models.QuerySet): The categories to display.
         outer_tag (str): The HTML tag to wrap the categories in.
@@ -171,13 +173,14 @@ def categories_html(
     if not categories:
         return ""
 
-    if outer_tag == "ul":
+    if outer_tag in {"ul", "ol"}:
         items_html = format_html_join(
             "",
             "<li>{}</li>",
             ((get_category_link(category, link_class),) for category in categories),
         )
-        return wrap_in_tag(items_html, "ul", outer_class)
+        wrapped = wrap_in_tag(items_html, outer_tag, outer_class)
+        return format_html("{}{}{}", pre_text, wrapped, post_text)
 
     escaped_separator = conditional_escape(separator)
     links = [get_category_link(category, link_class) for category in categories]

--- a/src/djpress/templatetags/helpers.py
+++ b/src/djpress/templatetags/helpers.py
@@ -192,12 +192,14 @@ def categories_html(
 
 def tags_html(
     tags: models.QuerySet,
+    *,
     outer_tag: str,
     outer_class: str,
     link_class: str,
     separator: str,
     pre_text: str,
     post_text: str,
+    show_post_count: bool = False,
 ) -> str | SafeString:
     """Return the HTML for the tags.
 
@@ -211,6 +213,7 @@ def tags_html(
         separator (str): The separator to use between tags.
         pre_text (str): The text to display before the tags.
         post_text (str): The text to display after the tags.
+        show_post_count (bool): Whether to display post counts.
 
     Returns:
         str | SafeString: The HTML for the tags.
@@ -218,17 +221,28 @@ def tags_html(
     if not tags:
         return ""
 
-    if outer_tag == "ul":
-        items_html = format_html_join(
-            "",
-            "<li>{}</li>",
-            ((get_tag_link(tag, link_class),) for tag in tags),
-        )
-        return wrap_in_tag(items_html, "ul", outer_class)
+    if outer_tag in {"ul", "ol"}:
+        if show_post_count:
+            items_html = format_html_join(
+                "",
+                "<li>{} ({})</li>",
+                ((get_tag_link(tag, link_class), getattr(tag, "num_posts", 0)) for tag in tags),
+            )
+        else:
+            items_html = format_html_join(
+                "",
+                "<li>{}</li>",
+                ((get_tag_link(tag, link_class),) for tag in tags),
+            )
+        return wrap_in_tag(items_html, outer_tag, outer_class)
+
+    if show_post_count:
+        items = [format_html("{} ({})", get_tag_link(tag, link_class), getattr(tag, "num_posts", 0)) for tag in tags]
+    else:
+        items = [get_tag_link(tag, link_class) for tag in tags]
 
     escaped_separator = conditional_escape(separator)
-    links = [get_tag_link(tag, link_class) for tag in tags]
-    joined_links = mark_safe(escaped_separator.join(links))
+    joined_links = mark_safe(escaped_separator.join(items))
 
     content = format_html("{}{}{}", pre_text, joined_links, post_text)
     return wrap_in_tag(content, outer_tag, outer_class)

--- a/tests/test_models_tag.py
+++ b/tests/test_models_tag.py
@@ -221,20 +221,52 @@ def test_tag_has_posts(test_post1, test_post2, tag1, tag2):
 
 
 @pytest.mark.django_db
-def test_get_tag_published(test_post1, test_post2, tag1, tag2):
-    assert list(Tag.objects.get_tags_with_published_posts()) == []
+def test_get_tags_with_counts(test_post1, test_post2, tag1, tag2, tag3):
+    # Initially no tags have published posts
+    tags = list(Tag.objects.get_tags_with_counts(published_only=True))
+    assert tags == []
 
+    # If published_only=False, all tags should be returned with num_posts=0
+    all_tags = list(Tag.objects.get_tags_with_counts(published_only=False).order_by("title"))
+    assert len(all_tags) == 3
+    assert {t.title for t in all_tags} == {tag1.title, tag2.title, tag3.title}
+    for tag in all_tags:
+        assert tag.num_posts == 0
+
+    # Associate posts with tags
     test_post1.tags.add(tag1)
     test_post2.tags.add(tag2)
-    assert list(Tag.objects.get_tags_with_published_posts()) == [tag1, tag2]
 
+    # Now get_tags_with_counts(published_only=True) should return tag1 and tag2, sorted or not, let's sort them
+    published_tags = list(Tag.objects.get_tags_with_counts(published_only=True).order_by("title"))
+    assert len(published_tags) == 2
+    # Check that the annotated count is 1 for each
+    tag1_with_count = next(t for t in published_tags if t.pk == tag1.pk)
+    tag2_with_count = next(t for t in published_tags if t.pk == tag2.pk)
+    assert tag1_with_count.num_posts == 1
+    assert tag2_with_count.num_posts == 1
+
+    # When test_post1 becomes a draft, it shouldn't be counted, and tag1 shouldn't be returned when published_only=True
     test_post1.status = "draft"
     test_post1.save()
-    assert list(Tag.objects.get_tags_with_published_posts()) == [tag2]
+    published_tags = list(Tag.objects.get_tags_with_counts(published_only=True))
+    assert len(published_tags) == 1
+    assert published_tags[0].pk == tag2.pk
+    assert published_tags[0].num_posts == 1
 
+    # If published_only=False, tag1 is still returned but with count 0
+    all_tags = list(Tag.objects.get_tags_with_counts(published_only=False).order_by("title"))
+    assert len(all_tags) == 3
+    tag1_with_count = next(t for t in all_tags if t.pk == tag1.pk)
+    tag2_with_count = next(t for t in all_tags if t.pk == tag2.pk)
+    assert tag1_with_count.num_posts == 0
+    assert tag2_with_count.num_posts == 1
+
+    # When test_post2 published_at is set to future, tag2 shouldn't be returned when published_only=True
     test_post2.published_at = timezone.now() + timezone.timedelta(days=1)
     test_post2.save()
-    assert list(Tag.objects.get_tags_with_published_posts()) == []
+    published_tags = list(Tag.objects.get_tags_with_counts(published_only=True))
+    assert published_tags == []
 
 
 @pytest.mark.django_db

--- a/tests/test_templatetags_djpress_tags.py
+++ b/tests/test_templatetags_djpress_tags.py
@@ -1006,8 +1006,31 @@ def test_site_categories(category1, category2):
     assert category1 in categories
     assert category2 in categories
 
-    assert djpress_tags.site_categories() == categories_html(
-        categories=categories, outer_tag="ul", outer_class="", link_class="", separator=", ", pre_text="", post_text=""
+    expected_html = '<ul><li><a href="/test-url-category/test-category1/" title="View all posts in the Test Category1 category" class="p-category">Test Category1</a></li><li><a href="/test-url-category/test-category2/" title="View all posts in the Test Category2 category" class="p-category">Test Category2</a></li></ul>'
+    assert djpress_tags.site_categories() == expected_html
+
+    expected_html_pre_text = '<h2>Categories</h2><ul><li><a href="/test-url-category/test-category1/" title="View all posts in the Test Category1 category" class="p-category">Test Category1</a></li><li><a href="/test-url-category/test-category2/" title="View all posts in the Test Category2 category" class="p-category">Test Category2</a></li></ul>'
+    assert djpress_tags.site_categories(pre_text=mark_safe("<h2>Categories</h2>")) == expected_html_pre_text
+
+    expected_html_post_text = '<ul><li><a href="/test-url-category/test-category1/" title="View all posts in the Test Category1 category" class="p-category">Test Category1</a></li><li><a href="/test-url-category/test-category2/" title="View all posts in the Test Category2 category" class="p-category">Test Category2</a></li></ul><h2>Categories</h2>'
+    assert djpress_tags.site_categories(post_text=mark_safe("<h2>Categories</h2>")) == expected_html_post_text
+
+    expected_html_div = '<div><a href="/test-url-category/test-category1/" title="View all posts in the Test Category1 category" class="p-category">Test Category1</a>, <a href="/test-url-category/test-category2/" title="View all posts in the Test Category2 category" class="p-category">Test Category2</a></div>'
+    assert djpress_tags.site_categories(outer_tag="div") == expected_html_div
+
+    expected_html_div_separator = '<div><a href="/test-url-category/test-category1/" title="View all posts in the Test Category1 category" class="p-category">Test Category1</a> | <a href="/test-url-category/test-category2/" title="View all posts in the Test Category2 category" class="p-category">Test Category2</a></div>'
+    assert djpress_tags.site_categories(outer_tag="div", separator=" | ") == expected_html_div_separator
+
+    expected_html_div_pre_text = '<div><h2>Categories</h2><a href="/test-url-category/test-category1/" title="View all posts in the Test Category1 category" class="p-category">Test Category1</a>, <a href="/test-url-category/test-category2/" title="View all posts in the Test Category2 category" class="p-category">Test Category2</a></div>'
+    assert (
+        djpress_tags.site_categories(outer_tag="div", pre_text=mark_safe("<h2>Categories</h2>"))
+        == expected_html_div_pre_text
+    )
+
+    expected_html_div_post_text = '<div><a href="/test-url-category/test-category1/" title="View all posts in the Test Category1 category" class="p-category">Test Category1</a>, <a href="/test-url-category/test-category2/" title="View all posts in the Test Category2 category" class="p-category">Test Category2</a><h2>Categories</h2></div>'
+    assert (
+        djpress_tags.site_categories(outer_tag="div", post_text=mark_safe("<h2>Categories</h2>"))
+        == expected_html_div_post_text
     )
 
 

--- a/tests/test_templatetags_djpress_tags.py
+++ b/tests/test_templatetags_djpress_tags.py
@@ -7,6 +7,7 @@ from django.core.paginator import Paginator
 from django.template import Context, Template
 from django.urls import reverse
 from django.db import models
+from django.utils.safestring import mark_safe
 
 from djpress.models import Category, Post, Tag
 from djpress.templatetags import djpress_tags
@@ -2831,6 +2832,14 @@ def test_site_archives(user, settings):
         f'<ul><li><a href="/{prefix}/2024/06/" title="View all posts from June 2024">June 2024</a> (1)</li></ul>'
     )
     assert djpress_tags.site_archives(show_post_count=True) == expected_html_with_count
+
+    expected_html_with_pre_text = f'<h2>Archives:</h2><ul><li><a href="/{prefix}/2024/06/" title="View all posts from June 2024">June 2024</a></li></ul>'
+    # Note that when used in a template, pre_text is marked as safe, so we need to do that here.
+    assert djpress_tags.site_archives(pre_text=mark_safe("<h2>Archives:</h2>")) == expected_html_with_pre_text
+
+    expected_html_with_post_text = f'<ul><li><a href="/{prefix}/2024/06/" title="View all posts from June 2024">June 2024</a></li></ul><div>Archives:</div>'
+    # Note that when used in a template, post_text is marked as safe, so we need to do that here.
+    assert djpress_tags.site_archives(post_text=mark_safe("<div>Archives:</div>")) == expected_html_with_post_text
 
     # Test site_archives when get_archives returns empty
     settings.DJPRESS_SETTINGS["ARCHIVE_ENABLED"] = False

--- a/tests/test_templatetags_djpress_tags.py
+++ b/tests/test_templatetags_djpress_tags.py
@@ -1057,12 +1057,12 @@ def test_site_tags_no_tags():
 
 
 @pytest.mark.django_db
-def test_tags_with_counts(test_post1, test_post2, tag1, tag2, tag3):
+def test_site_tags_with_counts(test_post1, test_post2, tag1, tag2, tag3):
     test_post1.tags.add(tag1)
     test_post2.tags.add(tag2)
 
     # Only tags 1 and 2 have posts, tag3 is empty
-    result = djpress_tags.tags_with_counts()
+    result = djpress_tags.site_tags(show_post_count=True)
 
     # Should only show tags with published posts
     assert tag1.title in result
@@ -2372,12 +2372,12 @@ def test_post_tags(test_post1, tag1):
 
 
 @pytest.mark.django_db
-def test_tags_with_counts_outer_div(test_post1, test_post2, tag1, tag2):
-    """Test tags_with_counts with div as outer tag."""
+def test_site_tags_with_counts_outer_div(test_post1, test_post2, tag1, tag2):
+    """Test site_tags with counts with div as outer tag."""
     test_post1.tags.add(tag1)
     test_post2.tags.add(tag2)
 
-    result = djpress_tags.tags_with_counts(outer_tag="div", outer_class="tag-list")
+    result = djpress_tags.site_tags(outer_tag="div", outer_class="tag-list", show_post_count=True)
 
     assert '<div class="tag-list">' in result
     assert tag1.title in result
@@ -2386,23 +2386,23 @@ def test_tags_with_counts_outer_div(test_post1, test_post2, tag1, tag2):
 
 
 @pytest.mark.django_db
-def test_tags_with_counts_incorrect_outer_div(test_post1, test_post2, tag1, tag2):
-    """Test tags_with_counts with incorrect outer tag."""
+def test_site_tags_with_counts_incorrect_outer_div(test_post1, test_post2, tag1, tag2):
+    """Test site_tags with counts with incorrect outer tag."""
     test_post1.tags.add(tag1)
     test_post2.tags.add(tag2)
 
-    result = djpress_tags.tags_with_counts(outer_tag="main", outer_class="tag-list")
+    result = djpress_tags.site_tags(outer_tag="main", outer_class="tag-list", show_post_count=True)
 
     assert result == ""
 
 
 @pytest.mark.django_db
-def test_tags_with_counts_outer_span(test_post1, test_post2, tag1, tag2):
-    """Test tags_with_counts with span as outer tag."""
+def test_site_tags_with_counts_outer_span(test_post1, test_post2, tag1, tag2):
+    """Test site_tags with counts with span as outer tag."""
     test_post1.tags.add(tag1)
     test_post2.tags.add(tag2)
 
-    result = djpress_tags.tags_with_counts(outer_tag="span", outer_class="tag-list")
+    result = djpress_tags.site_tags(outer_tag="span", outer_class="tag-list", show_post_count=True)
 
     assert '<span class="tag-list">' in result
     assert tag1.title in result
@@ -2411,14 +2411,14 @@ def test_tags_with_counts_outer_span(test_post1, test_post2, tag1, tag2):
 
 
 @pytest.mark.django_db
-def test_tags_with_counts_empty():
-    """Test tags_with_counts when there are no tags with published posts."""
-    result = djpress_tags.tags_with_counts()
+def test_site_tags_with_counts_empty():
+    """Test site_tags with counts when there are no tags with published posts."""
+    result = djpress_tags.site_tags(show_post_count=True)
     assert result == ""
 
 
 @pytest.mark.django_db
-def test_tags_with_counts_xss(test_post1):
+def test_site_tags_with_counts_xss(test_post1):
     """Make sure user-generated content is escaped."""
     bad_string = '<script>alert("evil")</script>'
     escaped_string = "&lt;script&gt;alert(&quot;evil&quot;)&lt;/script&gt;"
@@ -2426,8 +2426,8 @@ def test_tags_with_counts_xss(test_post1):
     tag = Tag.objects.create(slug="evil", title=bad_string)
     test_post1.tags.add(tag)
 
-    assert bad_string not in djpress_tags.tags_with_counts()
-    assert escaped_string in djpress_tags.tags_with_counts()
+    assert bad_string not in djpress_tags.site_tags(show_post_count=True)
+    assert escaped_string in djpress_tags.site_tags(show_post_count=True)
 
 
 @pytest.mark.django_db

--- a/tests/test_templatetags_helpers.py
+++ b/tests/test_templatetags_helpers.py
@@ -399,6 +399,59 @@ def test_tags_html(settings, tag1, tag2, tag3):
         == expected_output
     )
 
+    # Test case: show_post_count=True with ul
+    outer = "ul"
+    outer_class = "tags"
+    link_class = "tag"
+    # Annotate tags with some artificial post counts to test getattr(tag, "num_posts", 0)
+    for i, t in enumerate(tags):
+        t.num_posts = i + 1
+    expected_output = (
+        '<ul class="tags">'
+        f'<li><a href="/{settings.DJPRESS_SETTINGS["TAG_PREFIX"]}/{tag1.slug}/" title="View all posts tagged with {tag1.title}" class="{link_class}">{tag1.title}</a> (1)</li>'
+        f'<li><a href="/{settings.DJPRESS_SETTINGS["TAG_PREFIX"]}/{tag2.slug}/" title="View all posts tagged with {tag2.title}" class="{link_class}">{tag2.title}</a> (2)</li>'
+        f'<li><a href="/{settings.DJPRESS_SETTINGS["TAG_PREFIX"]}/{tag3.slug}/" title="View all posts tagged with {tag3.title}" class="{link_class}">{tag3.title}</a> (3)</li>'
+        "</ul>"
+    )
+    assert (
+        tags_html(
+            tags,
+            outer_tag=outer,
+            outer_class=outer_class,
+            link_class=link_class,
+            separator=", ",
+            pre_text="",
+            post_text="",
+            show_post_count=True,
+        )
+        == expected_output
+    )
+
+    # Test case: show_post_count=True with span
+    outer = "span"
+    outer_class = "tags"
+    link_class = "tag"
+    expected_output = (
+        '<span class="tags">'
+        f'<a href="/{settings.DJPRESS_SETTINGS["TAG_PREFIX"]}/{tag1.slug}/" title="View all posts tagged with {tag1.title}" class="{link_class}">{tag1.title}</a> (1), '
+        f'<a href="/{settings.DJPRESS_SETTINGS["TAG_PREFIX"]}/{tag2.slug}/" title="View all posts tagged with {tag2.title}" class="{link_class}">{tag2.title}</a> (2), '
+        f'<a href="/{settings.DJPRESS_SETTINGS["TAG_PREFIX"]}/{tag3.slug}/" title="View all posts tagged with {tag3.title}" class="{link_class}">{tag3.title}</a> (3)'
+        "</span>"
+    )
+    assert (
+        tags_html(
+            tags,
+            outer_tag=outer,
+            outer_class=outer_class,
+            link_class=link_class,
+            separator=", ",
+            pre_text="",
+            post_text="",
+            show_post_count=True,
+        )
+        == expected_output
+    )
+
 
 def test_tags_html_no_tags():
     tags = Tag.objects.none()

--- a/tests/test_templatetags_helpers.py
+++ b/tests/test_templatetags_helpers.py
@@ -209,13 +209,11 @@ def test_tags_html(settings, tag1, tag2, tag3):
     tags = Tag.objects.get_tags()
     assert list(tags) == [tag1, tag2, tag3]
 
-    # Test case - ul with options: pre_text, post_text, and spearator are ignored
+    # Test case - ul with spearator is ignored
     outer = "ul"
     outer_class = "tags"
     link_class = "tag"
     separator = " * "
-    pre_text = "this will be ignored"
-    post_text = "this will be ignored"
     expected_output = (
         '<ul class="tags">'
         f'<li><a href="/{settings.DJPRESS_SETTINGS["TAG_PREFIX"]}/{tag1.slug}/" title="View all posts tagged with {tag1.title}" class="p-category {link_class}">{tag1.title}</a></li>'
@@ -230,8 +228,8 @@ def test_tags_html(settings, tag1, tag2, tag3):
             outer_class=outer_class,
             link_class=link_class,
             separator=separator,
-            pre_text=pre_text,
-            post_text=post_text,
+            pre_text="",
+            post_text="",
         )
         == expected_output
     )
@@ -427,6 +425,31 @@ def test_tags_html(settings, tag1, tag2, tag3):
         == expected_output
     )
 
+    # Test case: show_post_count=True with ul
+    # Annotate tags with some artificial post counts to test getattr(tag, "num_posts", 0)
+    for i, t in enumerate(tags):
+        t.num_posts = i + 1
+    expected_output = (
+        'pre_text<ul class="tags">'
+        f'<li><a href="/{settings.DJPRESS_SETTINGS["TAG_PREFIX"]}/{tag1.slug}/" title="View all posts tagged with {tag1.title}" class="{link_class}">{tag1.title}</a> (1)</li>'
+        f'<li><a href="/{settings.DJPRESS_SETTINGS["TAG_PREFIX"]}/{tag2.slug}/" title="View all posts tagged with {tag2.title}" class="{link_class}">{tag2.title}</a> (2)</li>'
+        f'<li><a href="/{settings.DJPRESS_SETTINGS["TAG_PREFIX"]}/{tag3.slug}/" title="View all posts tagged with {tag3.title}" class="{link_class}">{tag3.title}</a> (3)</li>'
+        "</ul>post_text"
+    )
+    assert (
+        tags_html(
+            tags,
+            outer_tag="ul",
+            outer_class="tags",
+            link_class="tag",
+            separator=", ",
+            pre_text="pre_text",
+            post_text="post_text",
+            show_post_count=True,
+        )
+        == expected_output
+    )
+
     # Test case: show_post_count=True with span
     outer = "span"
     outer_class = "tags"
@@ -585,7 +608,7 @@ def test_archives_html():
         {"url": "/2026/05/", "label": "May 2026", "count": 1},
     ]
 
-    # Test case 1: default options (ul, no counts, no classes)
+    # Test case: default options (ul, no counts, no classes)
     expected_output = (
         "<ul>"
         '<li><a href="/2026/06/" title="View all posts from June 2026">June 2026</a></li>'
@@ -594,7 +617,7 @@ def test_archives_html():
     )
     assert archives_html(archives) == expected_output
 
-    # Test case 2: showing post counts in list
+    # Test case: showing post counts in list
     expected_output_counts = (
         "<ul>"
         '<li><a href="/2026/06/" title="View all posts from June 2026">June 2026</a> (3)</li>'
@@ -603,7 +626,7 @@ def test_archives_html():
     )
     assert archives_html(archives, show_post_count=True) == expected_output_counts
 
-    # Test case 3: ol tag with classes
+    # Test case: ol tag with classes
     expected_output_ol = (
         '<ol class="outer-c">'
         '<li class="li-c"><a href="/2026/06/" title="View all posts from June 2026" class="link-c">June 2026</a></li>'
@@ -621,7 +644,7 @@ def test_archives_html():
         == expected_output_ol
     )
 
-    # Test case 4: div with custom separator, pre_text, post_text
+    # Test case: div with custom separator, pre_text, post_text
     expected_output_div = (
         "Pre-text"
         '<div class="outer-c">'
@@ -644,10 +667,32 @@ def test_archives_html():
         == expected_output_div
     )
 
-    # Test case 5: empty list
+    # Test case: ul with custom separator, pre_text, post_text
+    expected_output_ul_pre_post_text = (
+        "Pre-text"
+        '<ul class="outer-c">'
+        '<li><a href="/2026/06/" title="View all posts from June 2026" class="link-c">June 2026</a> (3)</li>'
+        '<li><a href="/2026/05/" title="View all posts from May 2026" class="link-c">May 2026</a> (1)</li>'
+        "</ul>"
+        "Post-text"
+    )
+    assert (
+        archives_html(
+            archives,
+            outer_class="outer-c",
+            link_class="link-c",
+            separator=" | ",
+            show_post_count=True,
+            pre_text="Pre-text",
+            post_text="Post-text",
+        )
+        == expected_output_ul_pre_post_text
+    )
+
+    # Test case: empty list
     assert archives_html([]) == ""
 
-    # Test case 6: invalid tag defaults to ul
+    # Test case: invalid tag defaults to ul
     expected_invalid = (
         "<ul>"
         '<li><a href="/2026/06/" title="View all posts from June 2026">June 2026</a></li>'


### PR DESCRIPTION
Breaking change - remove the `tags_with_counts` template tag.
The `site_tags` template tag can now include counts
Fix the `categories_html` helper to include the pre and post text when using a list.
More tests