### PR TITLE
Configurable template path

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,7 @@ Settings are grouped by functionality:
 | Setting          | Type | Default   | Description                                                                     |
 |------------------|------|-----------|---------------------------------------------------------------------------------|
 | `THEME`          | str  | `default` | Which theme to use. See the [themes](themes.md) page for more details.          |
+| `TEMPLATE_PREFIX` | str  | `djpress/` | Directory prefix path for templates.                                            |
 | `THEME_SETTINGS` | dict | `{}`      | Optional theme settings. Refer to the specific theme documentation for details. |
 
 ### Example Configurations

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -7,7 +7,9 @@ This guide explains how to use existing themes, customise them, or create your o
 
 ### Template Files
 
-Template files must be placed in: `./templates/djpress/{{ your_theme_name }}/`
+By default, template files must be placed in: `./templates/djpress/{{ your_theme_name }}/`
+
+This path prefix can be customized using the `TEMPLATE_PREFIX` setting (which defaults to `"djpress/"`). For example, if `TEMPLATE_PREFIX` is set to `"my-blog/"`, template files should be placed in `./templates/my-blog/{{ your_theme_name }}/`.
 
 At minimum, a theme needs an `index.html` template. If this is the only template you provide, it will be used for all
 views. For more specialised layouts, you can create these additional templates:
@@ -53,7 +55,7 @@ DJPRESS_SETTINGS = {
 }
 ```
 
-The theme name must match the directory name under `templates/djpress/` and `static/djpress/`.
+The theme name must match the directory name under the template prefix folder (defined by `TEMPLATE_PREFIX`, e.g. `templates/djpress/`) and the static folder `static/djpress/`.
 
 ## Creating a Custom Theme
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "djpress"
-version = "0.27.2"
+version = "0.27.3"
 description = "A blog application for Django sites, inspired by classic WordPress."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -112,7 +112,7 @@ omit = ["*/tests/*", "*/migrations/*"]
 exclude_lines = ["if TYPE_CHECKING:", "# pragma: no cover"]
 
 [tool.bumpver]
-current_version = "0.27.2"
+current_version = "0.27.3"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "👍 bump version {old_version} -> {new_version}"
 commit = true

--- a/src/djpress/__init__.py
+++ b/src/djpress/__init__.py
@@ -1,3 +1,3 @@
 """djpress module."""
 
-__version__ = "0.27.2"
+__version__ = "0.27.3"

--- a/src/djpress/app_settings.py
+++ b/src/djpress/app_settings.py
@@ -33,6 +33,7 @@ DJPRESS_SETTINGS = {
     "SITE_TITLE": ("My DJ Press Blog", str),
     "TAG_ENABLED": (True, bool),
     "TAG_PREFIX": ("tag", str),
+    "TEMPLATE_PREFIX": ("djpress/", str),
     "THEME": ("default", str),
     "THEME_SETTINGS": ({}, dict),
     "TRUNCATE_TAG": ("<!--more-->", str),

--- a/src/djpress/utils.py
+++ b/src/djpress/utils.py
@@ -128,34 +128,35 @@ def get_templates(view_name: str) -> list[str]:
         list[str]: The list of template names.
     """
     theme = djpress_settings.THEME
+    prefix = djpress_settings.TEMPLATE_PREFIX
 
     template = ""
 
     if view_name == "index":
-        template = f"djpress/{theme}/home.html"
+        template = f"{prefix}{theme}/home.html"
 
     if view_name == "archive_posts":
-        template = f"djpress/{theme}/archives.html"
+        template = f"{prefix}{theme}/archives.html"
 
     if view_name == "category_posts":
-        template = f"djpress/{theme}/category.html"
+        template = f"{prefix}{theme}/category.html"
 
     if view_name == "tag_posts":
-        template = f"djpress/{theme}/tag.html"
+        template = f"{prefix}{theme}/tag.html"
 
     if view_name == "author_posts":
-        template = f"djpress/{theme}/author.html"
+        template = f"{prefix}{theme}/author.html"
 
     if view_name == "single_post":
-        template = f"djpress/{theme}/single.html"
+        template = f"{prefix}{theme}/single.html"
 
     if view_name == "single_page":
-        template = f"djpress/{theme}/page.html"
+        template = f"{prefix}{theme}/page.html"
 
     if view_name == "search":
-        template = f"djpress/{theme}/search.html"
+        template = f"{prefix}{theme}/search.html"
 
-    default_template = f"djpress/{theme}/index.html"
+    default_template = f"{prefix}{theme}/index.html"
 
     return [template, default_template] if template else [default_template]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -273,3 +273,32 @@ def test_get_template_name_testing_theme(settings):
     # Test case 7 - template for archive_posts view when archives.html exists
     template_name = get_template_name("archive_posts")
     assert template_name == "djpress/testing/archives.html"
+
+
+def test_get_templates_custom_prefix(settings):
+    """Verify that get_templates respects custom and empty TEMPLATE_PREFIX settings."""
+    settings.DJPRESS_SETTINGS["THEME"] = "test-theme"
+
+    # Test with a custom prefix ending with a slash
+    settings.DJPRESS_SETTINGS["TEMPLATE_PREFIX"] = "custom_templates/"
+    templates = get_templates("index")
+    assert templates == [
+        "custom_templates/test-theme/home.html",
+        "custom_templates/test-theme/index.html",
+    ]
+
+    # Test with a custom prefix not ending with a slash
+    settings.DJPRESS_SETTINGS["TEMPLATE_PREFIX"] = "my-prefix-"
+    templates = get_templates("index")
+    assert templates == [
+        "my-prefix-test-theme/home.html",
+        "my-prefix-test-theme/index.html",
+    ]
+
+    # Test with empty prefix
+    settings.DJPRESS_SETTINGS["TEMPLATE_PREFIX"] = ""
+    templates = get_templates("index")
+    assert templates == [
+        "test-theme/home.html",
+        "test-theme/index.html",
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -462,7 +462,7 @@ wheels = [
 
 [[package]]
 name = "djpress"
-version = "0.27.2"
+version = "0.27.3"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.15", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Make the template prefix configurable with new `TEMPLATE_PREFIX` setting.

This is set to `"djpress/"` by default so there's no change.