### PR TITLE
Prefetch tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "djpress"
-version = "0.29.7"
+version = "0.29.8"
 description = "A blog application for Django sites, inspired by classic WordPress."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -112,7 +112,7 @@ omit = ["*/tests/*", "*/migrations/*"]
 exclude_lines = ["if TYPE_CHECKING:", "# pragma: no cover"]
 
 [tool.bumpver]
-current_version = "0.29.7"
+current_version = "0.29.8"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "👍 bump version {old_version} -> {new_version}"
 commit = true

--- a/src/djpress/__init__.py
+++ b/src/djpress/__init__.py
@@ -1,3 +1,3 @@
 """djpress module."""
 
-__version__ = "0.29.7"
+__version__ = "0.29.8"

--- a/src/djpress/models/post.py
+++ b/src/djpress/models/post.py
@@ -308,7 +308,7 @@ class PostsManager(models.Manager.from_queryset(PostQuerySet)):
         - The status must be "published".
         - The date must be less than or equal to the current date/time.
         """
-        return self.get_queryset().prefetch_related("categories", "author")
+        return self.get_queryset().prefetch_related("categories", "tags", "author")
 
     def get_recent_published_posts(self) -> models.QuerySet:
         """Return recent published posts.
@@ -341,6 +341,7 @@ class PostsManager(models.Manager.from_queryset(PostQuerySet)):
                 self.model.admin_objects.filter(post_type="post", status="published")
                 .prefetch_related(
                     "categories",
+                    "tags",
                     "author",
                 )
                 .order_by("-published_at")


### PR DESCRIPTION
Prefetch tags when retrieving published posts. Prevents additional lookups in the templates.